### PR TITLE
AP-9751 # Added submission timestamp conditional logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **[BREAKING]** `evaluateConditionalPredicates()` now requires `submissionTimestamp: string`, `parseDate: (value: string) => Date`, and `addDaysToDate: (date: Date, offset: number) => Date`.
 - **[BREAKING]** `paymentService.checkForPaymentEvent()` and `schedulingService.checkForSchedulingEvent()` now take a single options object (`{ definition, submission, submissionTimestamp, parseDate, addDaysToDate }`).
+- **[BREAKING]** `generateFormElementsConditionallyShown()` now returns `{ formElementsConditionallyShown, isSubmissionEnabled }` and accepts optional `enableSubmission`. Form-fill submission enablement is evaluated here (visibility-aware) instead of a separate `evaluateConditionalPredicates()` call.
 
 ## [9.2.2] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for `SUBMISSION_TIMESTAMP` predicates in `conditionalLogicService.evaluateConditionalPredicates()`. Compare the form submission timestamp to a custom date or date/datetime element, with an optional day offset, using `AFTER`/`BEFORE` (exclusive) or `BETWEEN` (inclusive). Pass required `submissionTimestamp`, `parseDate`, and `addDaysToDate` helpers when evaluating so callers control timezone-aware parsing and calendar arithmetic. Client-side code evaluating during submission should pass `new Date().toISOString()`.
+
+### Changed
+
+- **[BREAKING]** `evaluateConditionalPredicates()` now requires `submissionTimestamp: string`, `parseDate: (value: string) => Date`, and `addDaysToDate: (date: Date, offset: number) => Date`.
+- **[BREAKING]** `paymentService.checkForPaymentEvent()` and `schedulingService.checkForSchedulingEvent()` now take a single options object (`{ definition, submission, submissionTimestamp, parseDate, addDaysToDate }`).
+
 ## [9.2.2] - 2026-07-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@microsoft/eslint-plugin-sdl": "^1.1.0",
         "@microsoft/microsoft-graph-types": "^2.43.1",
         "@oneblink/release-cli": "^4.0.0-beta.2",
-        "@oneblink/types": "github:oneblink/types#AP-9750",
+        "@oneblink/types": "github:oneblink/types",
         "@salesforce/types": "^1.6.0",
         "@spotto/contract": "^1.0.69-alpha.13",
         "@types/lodash": "^4.17.23",
@@ -645,7 +645,7 @@
     },
     "node_modules/@oneblink/types": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/oneblink/types.git#0445ceed26cb754fc0362878d464a4998e1655c0",
+      "resolved": "git+ssh://git@github.com/oneblink/types.git#2b991193e4c2f3e4236da7fa99780fb4c3546bf4",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@microsoft/eslint-plugin-sdl": "^1.1.0",
         "@microsoft/microsoft-graph-types": "^2.43.1",
         "@oneblink/release-cli": "^4.0.0-beta.2",
-        "@oneblink/types": "github:oneblink/types",
+        "@oneblink/types": "github:oneblink/types#AP-9750",
         "@salesforce/types": "^1.6.0",
         "@spotto/contract": "^1.0.69-alpha.13",
         "@types/lodash": "^4.17.23",
@@ -645,9 +645,9 @@
     },
     "node_modules/@oneblink/types": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/oneblink/types.git#7b9448e00309780bdd7d65993278231a7e30596d",
+      "resolved": "git+ssh://git@github.com/oneblink/types.git#0445ceed26cb754fc0362878d464a4998e1655c0",
       "dev": true,
-      "license": "GPL-3.0-only",
+      "license": "MIT",
       "dependencies": {
         "@types/google.maps": "^3.55.9"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -645,7 +645,7 @@
     },
     "node_modules/@oneblink/types": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/oneblink/types.git#2b991193e4c2f3e4236da7fa99780fb4c3546bf4",
+      "resolved": "git+ssh://git@github.com/oneblink/types.git#947d14016f0393a99338382039ace43970ac7eea",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@microsoft/eslint-plugin-sdl": "^1.1.0",
     "@microsoft/microsoft-graph-types": "^2.43.1",
     "@oneblink/release-cli": "^4.0.0-beta.2",
-    "@oneblink/types": "github:oneblink/types#AP-9750",
+    "@oneblink/types": "github:oneblink/types",
     "@salesforce/types": "^1.6.0",
     "@spotto/contract": "^1.0.69-alpha.13",
     "@types/lodash": "^4.17.23",
@@ -64,7 +64,7 @@
     "release": "oneblink-release repository --no-name",
     "start": "tsc-watch",
     "test": "vitest run",
-    "types": "npm install --save-dev github:oneblink/types#AP-9750",
+    "types": "npm install --save-dev github:oneblink/types",
     "typescript": "tsc --noEmit",
     "update-dependents": "oneblink-release update-dependents --force"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@microsoft/eslint-plugin-sdl": "^1.1.0",
     "@microsoft/microsoft-graph-types": "^2.43.1",
     "@oneblink/release-cli": "^4.0.0-beta.2",
-    "@oneblink/types": "github:oneblink/types",
+    "@oneblink/types": "github:oneblink/types#AP-9750",
     "@salesforce/types": "^1.6.0",
     "@spotto/contract": "^1.0.69-alpha.13",
     "@types/lodash": "^4.17.23",
@@ -64,7 +64,7 @@
     "release": "oneblink-release repository --no-name",
     "start": "tsc-watch",
     "test": "vitest run",
-    "types": "npm install --save-dev github:oneblink/types",
+    "types": "npm install --save-dev github:oneblink/types#AP-9750",
     "typescript": "tsc --noEmit",
     "update-dependents": "oneblink-release update-dependents --force"
   },

--- a/src/conditionalLogicService.ts
+++ b/src/conditionalLogicService.ts
@@ -1,8 +1,11 @@
-import evaluateConditionalPredicate from './conditionalLogicService/evaluateConditionalPredicate.js'
+import evaluateFormElementConditionalPredicate from './conditionalLogicService/evaluateFormElementConditionalPredicate.js'
+import evaluateConditionalSubmissionTimestampPredicate from './conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.js'
 import { flattenFormElements } from './formElementsService.js'
 import { ConditionTypes, FormTypes, SubmissionTypes } from '@oneblink/types'
+import { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
 
 export * from './conditionalLogicService/generateFormElementsConditionallyShown.js'
+export type { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
 
 /**
  * Given a set of form elements and submission data, evaluate if predicates are
@@ -59,6 +62,12 @@ export * from './conditionalLogicService/generateFormElementsConditionallyShown.
  *         requiresAllConditionallyShowPredicates: false,
  *       },
  *     ],
+ *     submissionTimestamp: new Date().toISOString(),
+ *     parseDate: (value) => new Date(value),
+ *     addDaysToDate: (date, days) => {
+ *       date.setUTCDate(date.getUTCDate() + days)
+ *       return date
+ *     },
  *   },
  * )
  * ```
@@ -72,12 +81,21 @@ export function evaluateConditionalPredicates({
   conditionalPredicates,
   formElements,
   submission,
+  submissionTimestamp,
+  parseDate,
+  addDaysToDate,
 }: {
   isConditional: boolean
   requiresAllConditionalPredicates: boolean
   conditionalPredicates: ConditionTypes.ConditionalPredicate[]
   formElements: FormTypes.FormElement[]
   submission: SubmissionTypes.S3SubmissionData['submission']
+  /** ISO timestamp the form was submitted. When evaluating during submission, pass `new Date().toISOString()`. */
+  submissionTimestamp: string
+  /** Parse date/datetime strings when evaluating date based predicates */
+  parseDate: ParseDate
+  /** Add days to a date when evaluating date based predicates */
+  addDaysToDate: AddOffsetToDate
 }): boolean {
   if (!isConditional || !conditionalPredicates.length) {
     return true
@@ -87,11 +105,22 @@ export function evaluateConditionalPredicates({
     model: submission,
   }
 
-  const predicateFn = (predicate: ConditionTypes.ConditionalPredicate) =>
-    evaluateConditionalPredicate({
+  const predicateFn = (predicate: ConditionTypes.ConditionalPredicate) => {
+    if (predicate.type === 'SUBMISSION_TIMESTAMP') {
+      return evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp,
+        parseDate,
+        addDaysToDate,
+      })
+    }
+
+    return !!evaluateFormElementConditionalPredicate({
       predicate,
       formElementsCtrl,
     })
+  }
   if (requiresAllConditionalPredicates) {
     return conditionalPredicates.every(predicateFn)
   } else {

--- a/src/conditionalLogicService/conditionallyShowElement.ts
+++ b/src/conditionalLogicService/conditionallyShowElement.ts
@@ -1,6 +1,6 @@
 import { FormTypes, ConditionTypes } from '@oneblink/types'
 import { FormElementsCtrl } from './types.js'
-import evaluateConditionalPredicate from './evaluateConditionalPredicate.js'
+import evaluateFormElementConditionalPredicate from './evaluateFormElementConditionalPredicate.js'
 
 const getParentFormElements = (
   formElementsCtrl: FormElementsCtrl,
@@ -24,12 +24,16 @@ const getParentFormElements = (
   return []
 }
 
-export function conditionallyShowByPredicate(
-  formElementsCtrl: FormElementsCtrl,
-  predicate: ConditionTypes.ConditionalPredicate,
-  elementsEvaluated: Array<{ id: string; label: string }>,
-): boolean {
-  const predicateElement = evaluateConditionalPredicate({
+export function conditionallyShowByPredicate({
+  formElementsCtrl,
+  predicate,
+  elementsEvaluated,
+}: {
+  formElementsCtrl: FormElementsCtrl
+  predicate: ConditionTypes.FormElementConditionalPredicate
+  elementsEvaluated: Array<{ id: string; label: string }>
+}): boolean {
+  const predicateElement = evaluateFormElementConditionalPredicate({
     predicate,
     formElementsCtrl,
   })
@@ -48,27 +52,33 @@ export function conditionallyShowByPredicate(
   )
   for (const parentFormElement of parentFormElements) {
     if (
-      !conditionallyShowElement(formElementsCtrl, parentFormElement, [
-        ...elementsEvaluated,
-      ])
+      !conditionallyShowElement({
+        formElementsCtrl,
+        elementToEvaluate: parentFormElement,
+        elementsEvaluated: [...elementsEvaluated],
+      })
     ) {
       return false
     }
   }
 
   // Check to see if the model has one of the valid values to show the element
-  return conditionallyShowElement(
+  return conditionallyShowElement({
     formElementsCtrl,
-    predicateElement,
+    elementToEvaluate: predicateElement,
     elementsEvaluated,
-  )
+  })
 }
 
-export default function conditionallyShowElement(
-  formElementsCtrl: FormElementsCtrl,
-  elementToEvaluate: FormTypes.FormElement,
-  elementsEvaluated: Array<{ id: string; label: string }>,
-): boolean {
+export default function conditionallyShowElement({
+  formElementsCtrl,
+  elementToEvaluate,
+  elementsEvaluated,
+}: {
+  formElementsCtrl: FormElementsCtrl
+  elementToEvaluate: FormTypes.FormElement
+  elementsEvaluated: Array<{ id: string; label: string }>
+}): boolean {
   // If the element does not have the `conditionallyShow` flag set,
   // we can always show the element.
   if (
@@ -102,14 +112,16 @@ export default function conditionallyShowElement(
   }
 
   const predicateFunction = (
-    predicate: ConditionTypes.ConditionalPredicate,
+    predicate: ConditionTypes.FormElementConditionalPredicate,
   ) => {
     // Spread the array of elements evaluated so that each predicate can
     // evaluate the tree without causing false positives for infinite
     // loop conditional logic
-    return conditionallyShowByPredicate(formElementsCtrl, predicate, [
-      ...elementsEvaluated,
-    ])
+    return conditionallyShowByPredicate({
+      formElementsCtrl,
+      predicate,
+      elementsEvaluated: [...elementsEvaluated],
+    })
   }
 
   if (elementToEvaluate.requiresAllConditionallyShowPredicates) {

--- a/src/conditionalLogicService/conditionallyShowOption.ts
+++ b/src/conditionalLogicService/conditionallyShowOption.ts
@@ -10,11 +10,15 @@ export type ShouldShowOption =
   | 'LOADING_DYNAMIC_DEPENDENCY'
   | 'LOADING_STATIC_DEPENDENCY'
 
-const handleAttributePredicate = (
-  predicate: FormTypes.ChoiceElementOptionAttribute,
-  model: SubmissionTypes.S3SubmissionData['submission'] | undefined,
-  predicateElement: FormTypes.FormElementWithOptions,
-) => {
+const handleAttributePredicate = ({
+  predicate,
+  model,
+  predicateElement,
+}: {
+  predicate: FormTypes.ChoiceElementOptionAttribute
+  model: SubmissionTypes.S3SubmissionData['submission'] | undefined
+  predicateElement: FormTypes.FormElementWithOptions
+}) => {
   const values = model?.[predicateElement.name]
   if (!values) return true
 
@@ -37,11 +41,15 @@ const handleAttributePredicate = (
   })
 }
 
-const conditionallyShowOptionByPredicate = (
-  formElementsCtrl: FormElementsCtrl,
-  predicate: FormTypes.ChoiceElementOptionAttribute,
-  elementsEvaluated: string[],
-): ShouldShowOption => {
+const conditionallyShowOptionByPredicate = ({
+  formElementsCtrl,
+  predicate,
+  elementsEvaluated,
+}: {
+  formElementsCtrl: FormElementsCtrl
+  predicate: FormTypes.ChoiceElementOptionAttribute
+  elementsEvaluated: string[]
+}): ShouldShowOption => {
   // Validate the predicate data, if it is invalid,
   // we will always show the field
   if (
@@ -64,11 +72,11 @@ const conditionallyShowOptionByPredicate = (
   // in a parent list of elements.
   if (!predicateElement) {
     if (formElementsCtrl.parentFormElementsCtrl) {
-      return conditionallyShowOptionByPredicate(
-        formElementsCtrl.parentFormElementsCtrl,
+      return conditionallyShowOptionByPredicate({
+        formElementsCtrl: formElementsCtrl.parentFormElementsCtrl,
         predicate,
         elementsEvaluated,
-      )
+      })
     } else {
       return 'HIDE'
     }
@@ -100,12 +108,15 @@ const conditionallyShowOptionByPredicate = (
     )
     if (!predicateOption) return 'HIDE'
 
-    return conditionallyShowOption(
-      { model: formElementsCtrl.model, flattenedElements: [] },
-      optionsPredicateElement,
-      predicateOption,
-      elementsEvaluated,
-    )
+    return conditionallyShowOption({
+      formElementsCtrl: {
+        model: formElementsCtrl.model,
+        flattenedElements: [],
+      },
+      elementToEvaluate: optionsPredicateElement,
+      optionToEvaluate: predicateOption,
+      optionsEvaluated: elementsEvaluated,
+    })
   })
 
   if (!everyOptionIsShowing) {
@@ -113,19 +124,23 @@ const conditionallyShowOptionByPredicate = (
   }
 
   // Check to see if the model has one of the valid values to show the element
-  const shouldShow = handleAttributePredicate(
+  const shouldShow = handleAttributePredicate({
     predicate,
-    formElementsCtrl.model,
-    optionsPredicateElement,
-  )
+    model: formElementsCtrl.model,
+    predicateElement: optionsPredicateElement,
+  })
   return shouldShow ? 'SHOW' : 'HIDE'
 }
 
-const isAttributeFilterValid = (
-  formElementsCtrl: FormElementsCtrl,
-  predicate: FormTypes.ChoiceElementOptionAttribute,
-  elementsEvaluated: string[],
-): boolean => {
+const isAttributeFilterValid = ({
+  formElementsCtrl,
+  predicate,
+  elementsEvaluated,
+}: {
+  formElementsCtrl: FormElementsCtrl
+  predicate: FormTypes.ChoiceElementOptionAttribute
+  elementsEvaluated: string[]
+}): boolean => {
   const predicateElement = formElementsCtrl.flattenedElements.find(
     (element) => {
       return element.id === predicate.elementId
@@ -138,11 +153,11 @@ const isAttributeFilterValid = (
   // in a parent list of elements.
   if (!predicateElement) {
     if (formElementsCtrl.parentFormElementsCtrl) {
-      return isAttributeFilterValid(
-        formElementsCtrl.parentFormElementsCtrl,
+      return isAttributeFilterValid({
+        formElementsCtrl: formElementsCtrl.parentFormElementsCtrl,
         predicate,
         elementsEvaluated,
-      )
+      })
     } else {
       return false
     }
@@ -154,7 +169,11 @@ const isAttributeFilterValid = (
     // Will never be a page, just making typescript happy :)
     predicateElement.type === 'page' ||
     predicateElement.type === 'section' ||
-    !conditionallyShowElement(formElementsCtrl, predicateElement, [])
+    !conditionallyShowElement({
+      formElementsCtrl,
+      elementToEvaluate: predicateElement,
+      elementsEvaluated: [],
+    })
   ) {
     return false
   }
@@ -174,12 +193,17 @@ const isAttributeFilterValid = (
   return true
 }
 
-export default function conditionallyShowOption(
-  formElementsCtrl: FormElementsCtrl,
-  elementToEvaluate: FormTypes.FormElementWithOptions,
-  optionToEvaluate: FormTypes.ChoiceElementOption,
-  optionsEvaluated: string[],
-): ShouldShowOption {
+export default function conditionallyShowOption({
+  formElementsCtrl,
+  elementToEvaluate,
+  optionToEvaluate,
+  optionsEvaluated,
+}: {
+  formElementsCtrl: FormElementsCtrl
+  elementToEvaluate: FormTypes.FormElementWithOptions
+  optionToEvaluate: FormTypes.ChoiceElementOption
+  optionsEvaluated: string[]
+}): ShouldShowOption {
   // If the element does not have the `conditionallyShow` flag set,
   // we can always show the option.
 
@@ -204,11 +228,11 @@ export default function conditionallyShowOption(
   }
   const validPredicates = (optionToEvaluate.attributes || []).filter(
     (predicate) => {
-      return isAttributeFilterValid(
+      return isAttributeFilterValid({
         formElementsCtrl,
         predicate,
-        optionsEvaluated,
-      )
+        elementsEvaluated: optionsEvaluated,
+      })
     },
   )
   if (!validPredicates.length) return 'SHOW'
@@ -218,11 +242,11 @@ export default function conditionallyShowOption(
   const showResults = Array(validPredicates.length).fill(false)
   for (let i = 0; i < validPredicates.length; i++) {
     const predicate = validPredicates[i]
-    const predicateResult = conditionallyShowOptionByPredicate(
+    const predicateResult = conditionallyShowOptionByPredicate({
       formElementsCtrl,
       predicate,
-      optionsEvaluated,
-    )
+      elementsEvaluated: optionsEvaluated,
+    })
     switch (predicateResult) {
       case 'SHOW': {
         if (elementToEvaluate.requiresAllConditionallyShowOptionsPredicates) {

--- a/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
+++ b/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
@@ -1,26 +1,6 @@
 import { ConditionTypes } from '@oneblink/types'
-import { typeCastService } from '../index.js'
 import { AddOffsetToDate, FormElementsCtrl, ParseDate } from './types.js'
-
-function getElementValue(
-  formElementsCtrl: FormElementsCtrl,
-  elementId: string,
-): string | undefined {
-  const formElement = formElementsCtrl.flattenedElements.find(
-    (element) => element.id === elementId,
-  )
-  if (formElement) {
-    const formElementWithName =
-      typeCastService.formElements.toNamedElement(formElement)
-    if (formElementWithName) {
-      const value = formElementsCtrl.model?.[formElementWithName.name]
-      return typeof value === 'string' && value ? value : undefined
-    }
-  } else if (formElementsCtrl.parentFormElementsCtrl) {
-    return getElementValue(formElementsCtrl.parentFormElementsCtrl, elementId)
-  }
-  return undefined
-}
+import { getElementAndValue } from './evaluateFormElementConditionalPredicate.js'
 
 function resolveDateValue(
   dateValue: ConditionTypes.ConditionalPredicateDateValue,
@@ -31,7 +11,13 @@ function resolveDateValue(
   let dateString: string | undefined
 
   if (dateValue.compareWith === 'ELEMENT') {
-    dateString = getElementValue(formElementsCtrl, dateValue.formElementId)
+    const elementAndValue = getElementAndValue(
+      formElementsCtrl,
+      dateValue.formElementId,
+    )
+    if (typeof elementAndValue.value === 'string' && elementAndValue.value) {
+      dateString = elementAndValue.value
+    }
     if (!dateString) {
       return undefined
     }

--- a/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
+++ b/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
@@ -1,0 +1,126 @@
+import { ConditionTypes } from '@oneblink/types'
+import { typeCastService } from '../index.js'
+import {
+  AddOffsetToDate,
+  FormElementsCtrl,
+  ParseDate,
+} from './types.js'
+
+function getElementValue(
+  formElementsCtrl: FormElementsCtrl,
+  elementId: string,
+): string | undefined {
+  const formElement = formElementsCtrl.flattenedElements.find(
+    (element) => element.id === elementId,
+  )
+  if (formElement) {
+    const formElementWithName =
+      typeCastService.formElements.toNamedElement(formElement)
+    if (formElementWithName) {
+      const value = formElementsCtrl.model?.[formElementWithName.name]
+      return typeof value === 'string' && value ? value : undefined
+    }
+  } else if (formElementsCtrl.parentFormElementsCtrl) {
+    return getElementValue(
+      formElementsCtrl.parentFormElementsCtrl,
+      elementId,
+    )
+  }
+  return undefined
+}
+
+function resolveDateValue(
+  dateValue: ConditionTypes.ConditionalPredicateDateValue,
+  formElementsCtrl: FormElementsCtrl,
+  parseDate: ParseDate,
+  addDaysToDate: AddOffsetToDate,
+): Date | undefined {
+  let dateString: string | undefined
+
+  if (dateValue.compareWith === 'ELEMENT') {
+    dateString = getElementValue(formElementsCtrl, dateValue.formElementId)
+    if (!dateString) {
+      return undefined
+    }
+  } else {
+    dateString = dateValue.value
+  }
+
+  const date = parseDate(dateString)
+  if (Number.isNaN(date.getTime())) {
+    return undefined
+  }
+
+  if (!dateValue.daysOffset) {
+    return date
+  }
+
+  return addDaysToDate(date, dateValue.daysOffset)
+}
+
+/**
+ * Evaluate a `SUBMISSION_TIMESTAMP` conditional predicate against the form
+ * submission timestamp.
+ *
+ * - `AFTER` — submission timestamp is after (exclusive) the comparison date
+ * - `BEFORE` — submission timestamp is before (exclusive) the comparison date
+ * - `BETWEEN` — submission timestamp is between `min` and `max` (inclusive)
+ *
+ * Date strings are parsed via `parseDate`. Day offsets are applied via
+ * `addDaysToDate(date, offset)`.
+ */
+export default function evaluateConditionalSubmissionTimestampPredicate({
+  predicate,
+  formElementsCtrl,
+  submissionTimestamp,
+  parseDate,
+  addDaysToDate,
+}: {
+  predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp
+  formElementsCtrl: FormElementsCtrl
+  submissionTimestamp: string
+  parseDate: ParseDate
+  addDaysToDate: AddOffsetToDate
+}): boolean {
+  const submissionDate = new Date(submissionTimestamp)
+  if (Number.isNaN(submissionDate.getTime())) {
+    return false
+  }
+
+  const submissionTime = submissionDate.getTime()
+
+  if (predicate.operator === 'BETWEEN') {
+    const min = resolveDateValue(
+      predicate.min,
+      formElementsCtrl,
+      parseDate,
+      addDaysToDate,
+    )
+    const max = resolveDateValue(
+      predicate.max,
+      formElementsCtrl,
+      parseDate,
+      addDaysToDate,
+    )
+    if (!min || !max) {
+      return false
+    }
+    return submissionTime >= min.getTime() && submissionTime <= max.getTime()
+  }
+
+  const compareDate = resolveDateValue(
+    predicate,
+    formElementsCtrl,
+    parseDate,
+    addDaysToDate,
+  )
+  if (!compareDate) {
+    return false
+  }
+
+  if (predicate.operator === 'AFTER') {
+    return submissionTime > compareDate.getTime()
+  }
+
+  return submissionTime < compareDate.getTime()
+}

--- a/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
+++ b/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
@@ -1,10 +1,6 @@
 import { ConditionTypes } from '@oneblink/types'
 import { typeCastService } from '../index.js'
-import {
-  AddOffsetToDate,
-  FormElementsCtrl,
-  ParseDate,
-} from './types.js'
+import { AddOffsetToDate, FormElementsCtrl, ParseDate } from './types.js'
 
 function getElementValue(
   formElementsCtrl: FormElementsCtrl,
@@ -21,10 +17,7 @@ function getElementValue(
       return typeof value === 'string' && value ? value : undefined
     }
   } else if (formElementsCtrl.parentFormElementsCtrl) {
-    return getElementValue(
-      formElementsCtrl.parentFormElementsCtrl,
-      elementId,
-    )
+    return getElementValue(formElementsCtrl.parentFormElementsCtrl, elementId)
   }
   return undefined
 }
@@ -51,7 +44,10 @@ function resolveDateValue(
     return undefined
   }
 
-  if (!dateValue.daysOffset) {
+  if (
+    typeof dateValue.daysOffset !== 'number' ||
+    Number.isNaN(dateValue.daysOffset)
+  ) {
     return date
   }
 

--- a/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
+++ b/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
@@ -71,38 +71,47 @@ export default function evaluateConditionalSubmissionTimestampPredicate({
 
   const submissionTime = submissionDate.getTime()
 
-  if (predicate.operator === 'BETWEEN') {
-    const min = resolveDateValue(
-      predicate.min,
-      formElementsCtrl,
-      parseDate,
-      addDaysToDate,
-    )
-    const max = resolveDateValue(
-      predicate.max,
-      formElementsCtrl,
-      parseDate,
-      addDaysToDate,
-    )
-    if (!min || !max) {
-      return false
+  switch (predicate.operator) {
+    case 'BETWEEN': {
+      const min = resolveDateValue(
+        predicate.min,
+        formElementsCtrl,
+        parseDate,
+        addDaysToDate,
+      )
+      const max = resolveDateValue(
+        predicate.max,
+        formElementsCtrl,
+        parseDate,
+        addDaysToDate,
+      )
+      if (!min || !max) {
+        return false
+      }
+      return submissionTime >= min.getTime() && submissionTime <= max.getTime()
     }
-    return submissionTime >= min.getTime() && submissionTime <= max.getTime()
-  }
+    default: {
+      const compareDate = resolveDateValue(
+        predicate,
+        formElementsCtrl,
+        parseDate,
+        addDaysToDate,
+      )
+      if (!compareDate) {
+        return false
+      }
 
-  const compareDate = resolveDateValue(
-    predicate,
-    formElementsCtrl,
-    parseDate,
-    addDaysToDate,
-  )
-  if (!compareDate) {
-    return false
+      switch (predicate.operator) {
+        case 'AFTER':
+          return submissionTime > compareDate.getTime()
+        case 'BEFORE':
+          return submissionTime < compareDate.getTime()
+        default: {
+          const n: never = predicate
+          console.warn('Unhandled predicate operator', n)
+          return false
+        }
+      }
+    }
   }
-
-  if (predicate.operator === 'AFTER') {
-    return submissionTime > compareDate.getTime()
-  }
-
-  return submissionTime < compareDate.getTime()
 }

--- a/src/conditionalLogicService/evaluateFormElementConditionalPredicate.ts
+++ b/src/conditionalLogicService/evaluateFormElementConditionalPredicate.ts
@@ -1,4 +1,4 @@
-import { FormTypes, ConditionTypes, SubmissionTypes } from '@oneblink/types'
+import { ConditionTypes, FormTypes, SubmissionTypes } from '@oneblink/types'
 import { FormElementsCtrl } from './types.js'
 import { typeCastService, formElementsService } from '../index.js'
 import evaluateConditionalOptionsPredicate from './evaluateConditionalOptionsPredicate.js'
@@ -39,11 +39,16 @@ function getElementAndValue(
   return {}
 }
 
-export default function evaluateConditionalPredicate({
+/**
+ * Evaluate an element-based conditional predicate. When the predicate is
+ * satisfied, returns the predicate form element so callers can also check
+ * whether that element (and its parents) are themselves shown.
+ */
+export default function evaluateFormElementConditionalPredicate({
   predicate,
   formElementsCtrl,
 }: {
-  predicate: ConditionTypes.ConditionalPredicate
+  predicate: ConditionTypes.FormElementConditionalPredicate
   formElementsCtrl: FormElementsCtrl
 }): FormTypes.FormElementWithName | undefined {
   const { formElementWithName: predicateElement, value: predicateValue } =
@@ -127,17 +132,17 @@ export default function evaluateConditionalPredicate({
       }
 
       for (const entry of repeatableSetValue) {
-        const result = conditionallyShowByPredicate(
-          {
+        const result = conditionallyShowByPredicate({
+          formElementsCtrl: {
             model: entry,
             flattenedElements: formElementsService.flattenFormElements(
               repeatableSetElement.elements,
             ),
             parentFormElementsCtrl: formElementsCtrl,
           },
-          predicate.repeatableSetPredicate,
-          [],
-        )
+          predicate: predicate.repeatableSetPredicate,
+          elementsEvaluated: [],
+        })
 
         if (result) {
           return predicateElement
@@ -158,15 +163,15 @@ export default function evaluateConditionalPredicate({
           | SubmissionTypes.S3SubmissionData['submission']
           | undefined
 
-        const result = conditionallyShowByPredicate(
-          {
+        const result = conditionallyShowByPredicate({
+          formElementsCtrl: {
             model: formModel,
             flattenedElements: flattenFormElements(predicateElement.elements),
             parentFormElementsCtrl: formElementsCtrl,
           },
-          predicate.predicate,
-          [],
-        )
+          predicate: predicate.predicate,
+          elementsEvaluated: [],
+        })
 
         if (result) {
           return predicateElement
@@ -269,7 +274,7 @@ export default function evaluateConditionalPredicate({
       break
     }
     case 'OPTIONS':
-    default: {
+    case undefined: {
       const optionsPredicateElement =
         typeCastService.formElements.toOptionsElement(predicateElement)
       if (!optionsPredicateElement) {

--- a/src/conditionalLogicService/evaluateFormElementConditionalPredicate.ts
+++ b/src/conditionalLogicService/evaluateFormElementConditionalPredicate.ts
@@ -14,7 +14,7 @@ const fnMap = {
   '<': (lhs: number, rhs: number) => lhs < rhs,
 }
 
-function getElementAndValue(
+export function getElementAndValue(
   formElementsCtrl: FormElementsCtrl,
   elementId: string,
 ): { formElementWithName?: FormTypes.FormElementWithName; value?: unknown } {

--- a/src/conditionalLogicService/generateFormElementsConditionallyShown.ts
+++ b/src/conditionalLogicService/generateFormElementsConditionallyShown.ts
@@ -35,27 +35,45 @@ export type FormElementConditionallyShown =
 
 export type ErrorCallback = (error: Error) => void
 
-const handleConditionallyShowElement = (
-  formElementsCtrl: FormElementsCtrl,
-  element: FormTypes.FormElement,
-  errorCallback: ErrorCallback | undefined,
-) => {
+const handleConditionallyShowElement = ({
+  formElementsCtrl,
+  element,
+  errorCallback,
+}: {
+  formElementsCtrl: FormElementsCtrl
+  element: FormTypes.FormElement
+  errorCallback: ErrorCallback | undefined
+}) => {
   try {
-    return conditionallyShowElement(formElementsCtrl, element, [])
+    return conditionallyShowElement({
+      formElementsCtrl,
+      elementToEvaluate: element,
+      elementsEvaluated: [],
+    })
   } catch (error) {
     errorCallback?.(error as Error)
     return false
   }
 }
 
-const handleConditionallyShowOption = (
-  formElementsCtrl: FormElementsCtrl,
-  element: FormTypes.FormElementWithOptions,
-  option: FormTypes.ChoiceElementOption,
-  errorCallback: ErrorCallback | undefined,
-): ShouldShowOption => {
+const handleConditionallyShowOption = ({
+  formElementsCtrl,
+  element,
+  option,
+  errorCallback,
+}: {
+  formElementsCtrl: FormElementsCtrl
+  element: FormTypes.FormElementWithOptions
+  option: FormTypes.ChoiceElementOption
+  errorCallback: ErrorCallback | undefined
+}): ShouldShowOption => {
   try {
-    return conditionallyShowOption(formElementsCtrl, element, option, [])
+    return conditionallyShowOption({
+      formElementsCtrl,
+      elementToEvaluate: element,
+      optionToEvaluate: option,
+      optionsEvaluated: [],
+    })
   } catch (error) {
     errorCallback?.(error as Error)
     return 'HIDE'
@@ -93,11 +111,11 @@ const generateFormElementsConditionallyShownWithParent = ({
             formElementsConditionallyShown[element.id]
           const isHidden = formElementConditionallyShown
             ? formElementConditionallyShown.isHidden
-            : !handleConditionallyShowElement(
+            : !handleConditionallyShowElement({
                 formElementsCtrl,
                 element,
                 errorCallback,
-              )
+              })
 
           formElementsConditionallyShown[element.id] = {
             type: 'formElement',
@@ -137,15 +155,16 @@ const generateFormElementsConditionallyShownWithParent = ({
             | undefined
           formElementsConditionallyShown[element.name] = {
             type: 'formElements',
-            isHidden: !handleConditionallyShowElement(
+            isHidden: !handleConditionallyShowElement({
               formElementsCtrl,
               element,
               errorCallback,
-            ),
+            }),
             formElements: generateFormElementsConditionallyShownWithParent({
               formElements: element.elements || [],
               submission: nestedModel || {},
               parentFormElementsCtrl: formElementsCtrl,
+              errorCallback,
             }),
           }
           break
@@ -159,11 +178,11 @@ const generateFormElementsConditionallyShownWithParent = ({
             | undefined
           formElementsConditionallyShown[element.name] = {
             type: 'repeatableSet',
-            isHidden: !handleConditionallyShowElement(
+            isHidden: !handleConditionallyShowElement({
               formElementsCtrl,
               element,
               errorCallback,
-            ),
+            }),
             entries: (entries || []).reduce(
               (
                 result: Record<
@@ -178,6 +197,7 @@ const generateFormElementsConditionallyShownWithParent = ({
                     formElements: element.elements,
                     submission: entry,
                     parentFormElementsCtrl: formElementsCtrl,
+                    errorCallback,
                   })
                 return result
               },
@@ -192,11 +212,11 @@ const generateFormElementsConditionallyShownWithParent = ({
           }
           const formElementConditionallyShown: FormElementConditionallyShown = {
             type: 'formElement',
-            isHidden: !handleConditionallyShowElement(
+            isHidden: !handleConditionallyShowElement({
               formElementsCtrl,
               element,
               errorCallback,
-            ),
+            }),
           }
 
           if (!formElementConditionallyShown.isHidden) {
@@ -209,12 +229,12 @@ const generateFormElementsConditionallyShownWithParent = ({
             ) {
               const newOptions = []
               for (const option of optionsElement.options) {
-                const optionPredicatesResult = handleConditionallyShowOption(
+                const optionPredicatesResult = handleConditionallyShowOption({
                   formElementsCtrl,
-                  optionsElement,
+                  element: optionsElement,
                   option,
                   errorCallback,
-                )
+                })
                 switch (optionPredicatesResult) {
                   case 'SHOW': {
                     newOptions.push(option)
@@ -307,7 +327,6 @@ const generateFormElementsConditionallyShownWithParent = ({
  *         isElementLookup: false,
  *       },
  *     ],
- *     parentFormElementsCtrl: undefined,
  *     errorCallback: (error) => {
  *       //do something with the error here
  *       console.error(error)

--- a/src/conditionalLogicService/generateFormElementsConditionallyShown.ts
+++ b/src/conditionalLogicService/generateFormElementsConditionallyShown.ts
@@ -6,6 +6,7 @@ import conditionallyShowOption, {
   ShouldShowOption,
 } from './conditionallyShowOption.js'
 import { typeCastService } from '../index.js'
+import evaluateFormElementConditionalPredicate from './evaluateFormElementConditionalPredicate.js'
 
 export type FormElementsConditionallyShown = Record<
   string,
@@ -87,6 +88,13 @@ export type FormElementsConditionallyShownParameters = {
   submission: SubmissionTypes.S3SubmissionData['submission']
   /** Optional callback for handling errors caught during the evaluation */
   errorCallback?: ErrorCallback
+  /** Conditionally enable form submission based on predicates */
+  enableSubmission: FormTypes.Form['enableSubmission'] | undefined
+}
+
+export type FormElementsConditionallyShownResult = {
+  formElementsConditionallyShown: FormElementsConditionallyShown
+  isSubmissionEnabled: boolean
 }
 
 const generateFormElementsConditionallyShownWithParent = ({
@@ -94,8 +102,11 @@ const generateFormElementsConditionallyShownWithParent = ({
   submission,
   parentFormElementsCtrl,
   errorCallback,
-}: FormElementsConditionallyShownParameters & {
-  parentFormElementsCtrl?: FormElementsCtrl['parentFormElementsCtrl']
+}: {
+  formElements: FormTypes.FormElement[]
+  submission: SubmissionTypes.S3SubmissionData['submission']
+  errorCallback: ErrorCallback | undefined
+  parentFormElementsCtrl: FormElementsCtrl['parentFormElementsCtrl'] | undefined
 }): FormElementsConditionallyShown => {
   const formElementsCtrl = {
     flattenedElements: flattenFormElements(formElements),
@@ -267,14 +278,14 @@ const generateFormElementsConditionallyShownWithParent = ({
 }
 
 /**
- * Given a form element and submission data, evaluate which elements are
- * currently shown. The function also takes an optional errorCallback for
- * handling errors caught during the evaluation.
+ * Given form elements and submission data, evaluate which elements are
+ * currently shown and whether submission is enabled. The function also takes an
+ * optional errorCallback for handling errors caught during the evaluation.
  *
  * #### Example
  *
  * ```js
- * const formElementsConditionallyShown =
+ * const { formElementsConditionallyShown, isSubmissionEnabled } =
  *   conditionalLogicService.generateFormElementsConditionallyShown({
  *     submission: {
  *       radio: ['hide'],
@@ -338,22 +349,79 @@ const generateFormElementsConditionallyShownWithParent = ({
  *
  * ```json
  * {
- *   "radio": {
- *     "isHidden": false,
- *     "type": "formElement"
+ *   "formElementsConditionallyShown": {
+ *     "radio": {
+ *       "isHidden": false,
+ *       "type": "formElement"
+ *     },
+ *     "text": {
+ *       "isHidden": true,
+ *       "type": "formElement"
+ *     }
  *   },
- *   "text": {
- *     "isHidden": true,
- *     "type": "formElement"
- *   }
+ *   "isSubmissionEnabled": true
  * }
  * ```
  *
  * @param parameters
  * @returns
  */
-export function generateFormElementsConditionallyShown(
-  parameters: FormElementsConditionallyShownParameters,
-): FormElementsConditionallyShown {
-  return generateFormElementsConditionallyShownWithParent(parameters)
+export function generateFormElementsConditionallyShown({
+  formElements,
+  submission,
+  errorCallback,
+  enableSubmission,
+}: FormElementsConditionallyShownParameters): FormElementsConditionallyShownResult {
+  const formElementsConditionallyShown =
+    generateFormElementsConditionallyShownWithParent({
+      formElements,
+      submission,
+      errorCallback,
+      parentFormElementsCtrl: undefined,
+    })
+
+  if (!enableSubmission?.conditionalPredicates.length) {
+    return {
+      formElementsConditionallyShown,
+      isSubmissionEnabled: true,
+    }
+  }
+
+  const formElementsCtrl: FormElementsCtrl = {
+    flattenedElements: flattenFormElements(formElements),
+    model: submission,
+  }
+
+  const predicateFn = (
+    predicate: NonNullable<
+      FormTypes.Form['enableSubmission']
+    >['conditionalPredicates'][number],
+  ) => {
+    try {
+      const predicateElement = evaluateFormElementConditionalPredicate({
+        predicate,
+        formElementsCtrl,
+      })
+      if (!predicateElement) {
+        return false
+      }
+
+      // Reuse visibility already computed above instead of re-evaluating
+      // conditionally show predicates for the predicate element / parents.
+      const shown = formElementsConditionallyShown[predicateElement.name]
+      return !!shown && !shown.isHidden
+    } catch (error) {
+      errorCallback?.(error as Error)
+      return false
+    }
+  }
+
+  const isSubmissionEnabled = enableSubmission.requiresAllConditionalPredicates
+    ? enableSubmission.conditionalPredicates.every(predicateFn)
+    : enableSubmission.conditionalPredicates.some(predicateFn)
+
+  return {
+    formElementsConditionallyShown,
+    isSubmissionEnabled,
+  }
 }

--- a/src/conditionalLogicService/types.ts
+++ b/src/conditionalLogicService/types.ts
@@ -1,5 +1,17 @@
 import { FormTypes, SubmissionTypes } from '@oneblink/types'
 
+/**
+ * Parse a date/datetime string into a `Date`. Callers supply timezone-aware
+ * parsing (e.g. treating `YYYY-MM-DD` as the start of day in an organisation
+ * timezone).
+ */
+export type ParseDate = (value: string) => Date
+
+/**
+ * Add an offset to a date. Callers supply timezone-aware calendar arithmetic.
+ */
+export type AddOffsetToDate = (date: Date, offset: number) => Date
+
 export type FormElementsCtrl = {
   model: SubmissionTypes.S3SubmissionData['submission'] | undefined
   flattenedElements: FormTypes.FormElement[]

--- a/src/paymentService.ts
+++ b/src/paymentService.ts
@@ -8,6 +8,7 @@ import {
   getRootElementValueById,
   ReplaceInjectablesFormatters,
 } from './submissionService.js'
+import { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
 
 /**
  * Examine a submission and its form definition to validate whether a payment
@@ -16,17 +17,37 @@ import {
  * #### Example
  *
  * ```js
- * const result = paymentService.checkForPaymentEvent(form, submission)
+ * const result = paymentService.checkForPaymentEvent({
+ *   definition: form,
+ *   submission,
+ *   submissionTimestamp,
+ *   parseDate: (value) => new Date(value),
+ *   addDaysToDate: (date, days) => {
+ *     date.setUTCDate(date.getUTCDate() + days)
+ *     return date
+ *   },
+ * })
  * ```
  *
- * @param definition
- * @param submission
+ * @param options
  * @returns
  */
-export function checkForPaymentEvent(
-  definition: FormTypes.Form,
-  submission: SubmissionTypes.S3SubmissionData['submission'],
-):
+export function checkForPaymentEvent({
+  definition,
+  submission,
+  submissionTimestamp,
+  parseDate,
+  addDaysToDate,
+}: {
+  definition: FormTypes.Form
+  submission: SubmissionTypes.S3SubmissionData['submission']
+  /** ISO timestamp the form was submitted. When evaluating during submission, pass `new Date().toISOString()`. */
+  submissionTimestamp: string
+  /** Parse date/datetime strings when evaluating date based predicates */
+  parseDate: ParseDate
+  /** Add days to a date when evaluating date based predicates */
+  addDaysToDate: AddOffsetToDate
+}):
   | {
       paymentSubmissionEvent: SubmissionEventTypes.FormPaymentEvent
       amount: number
@@ -45,6 +66,9 @@ export function checkForPaymentEvent(
             paymentSubmissionEvent.conditionallyExecutePredicates || [],
           submission: submission,
           formElements: definition.elements,
+          submissionTimestamp,
+          parseDate,
+          addDaysToDate,
         })
       )
     },

--- a/src/schedulingService.ts
+++ b/src/schedulingService.ts
@@ -4,6 +4,7 @@ import {
   SubmissionTypes,
 } from '@oneblink/types'
 import { conditionalLogicService } from './index.js'
+import { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
 
 /**
  * Examine a submission and its form definition to validate whether a scheduling
@@ -12,20 +13,37 @@ import { conditionalLogicService } from './index.js'
  * #### Example
  *
  * ```js
- * const result = schedulingService.checkFormSchedulingEvent(
- *   form,
+ * const result = schedulingService.checkForSchedulingEvent({
+ *   definition: form,
  *   submission,
- * )
+ *   submissionTimestamp,
+ *   parseDate: (value) => new Date(value),
+ *   addDaysToDate: (date, days) => {
+ *     date.setUTCDate(date.getUTCDate() + days)
+ *     return date
+ *   },
+ * })
  * ```
  *
- * @param definition
- * @param submission
+ * @param options
  * @returns
  */
-export function checkForSchedulingEvent(
-  definition: FormTypes.Form,
-  submission: SubmissionTypes.S3SubmissionData['submission'],
-): SubmissionEventTypes.FormSchedulingEvent | undefined {
+export function checkForSchedulingEvent({
+  definition,
+  submission,
+  submissionTimestamp,
+  parseDate,
+  addDaysToDate,
+}: {
+  definition: FormTypes.Form
+  submission: SubmissionTypes.S3SubmissionData['submission']
+  /** ISO timestamp the form was submitted. When evaluating during submission, pass `new Date().toISOString()`. */
+  submissionTimestamp: string
+  /** Parse date/datetime strings when evaluating date based predicates */
+  parseDate: ParseDate
+  /** Add days to a date when evaluating date based predicates */
+  addDaysToDate: AddOffsetToDate
+}): SubmissionEventTypes.FormSchedulingEvent | undefined {
   const schedulingSubmissionEvents = definition.schedulingEvents || []
   return schedulingSubmissionEvents.find((schedulingSubmissionEvent) =>
     conditionalLogicService.evaluateConditionalPredicates({
@@ -36,6 +54,9 @@ export function checkForSchedulingEvent(
         schedulingSubmissionEvent.conditionallyExecutePredicates || [],
       submission: submission,
       formElements: definition.elements,
+      submissionTimestamp,
+      parseDate,
+      addDaysToDate,
     }),
   )
 }

--- a/tests/conditionalLogicService.test.ts
+++ b/tests/conditionalLogicService.test.ts
@@ -97,6 +97,13 @@ describe('evaluateConditionalPredicates', () => {
       submission: {
         checkboxes: ['a'],
       },
+      submissionTimestamp: new Date().toISOString(),
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
+      },
     })
     expect(result).toBe(true)
   })
@@ -115,6 +122,13 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['b'],
+      },
+      submissionTimestamp: new Date().toISOString(),
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
       },
     })
     expect(result).toBe(false)
@@ -135,6 +149,13 @@ describe('evaluateConditionalPredicates', () => {
       submission: {
         radio: 'a',
       },
+      submissionTimestamp: new Date().toISOString(),
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
+      },
     })
     expect(result).toBe(true)
   })
@@ -153,6 +174,13 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         radio: 'b',
+      },
+      submissionTimestamp: new Date().toISOString(),
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
       },
     })
     expect(result).toBe(false)
@@ -178,6 +206,13 @@ describe('evaluateConditionalPredicates', () => {
       submission: {
         checkboxes: ['a', 'b'],
       },
+      submissionTimestamp: new Date().toISOString(),
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
+      },
     })
     expect(result).toBe(true)
   })
@@ -201,6 +236,13 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['a'],
+      },
+      submissionTimestamp: new Date().toISOString(),
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
       },
     })
     expect(result).toBe(false)
@@ -226,6 +268,13 @@ describe('evaluateConditionalPredicates', () => {
       submission: {
         checkboxes: ['a'],
       },
+      submissionTimestamp: new Date().toISOString(),
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
+      },
     })
     expect(resultA).toBe(true)
 
@@ -247,6 +296,13 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['b'],
+      },
+      submissionTimestamp: new Date().toISOString(),
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
       },
     })
     expect(resultB).toBe(true)
@@ -587,6 +643,12 @@ describe('generateFormElementsConditionallyShown', () => {
           ],
         },
       ],
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
+      },
     })
     expect(result).toEqual({
       comparisonNumber: {
@@ -768,6 +830,12 @@ describe('generateFormElementsConditionallyShown', () => {
         },
       ],
       errorCallback,
+      parseDate: (value) => new Date(value),
+      addDaysToDate: (date, days) => {
+        const result = new Date(date.getTime())
+        result.setUTCDate(result.getUTCDate() + days)
+        return result
+      },
     })
     expect(result).toEqual({
       first_option: {

--- a/tests/conditionalLogicService.test.ts
+++ b/tests/conditionalLogicService.test.ts
@@ -96,14 +96,7 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['a'],
-      },
-      submissionTimestamp: new Date().toISOString(),
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
+      }
     })
     expect(result).toBe(true)
   })
@@ -122,14 +115,7 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['b'],
-      },
-      submissionTimestamp: new Date().toISOString(),
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
+      }
     })
     expect(result).toBe(false)
   })
@@ -148,14 +134,7 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         radio: 'a',
-      },
-      submissionTimestamp: new Date().toISOString(),
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
+      }
     })
     expect(result).toBe(true)
   })
@@ -174,14 +153,7 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         radio: 'b',
-      },
-      submissionTimestamp: new Date().toISOString(),
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
+      }
     })
     expect(result).toBe(false)
   })
@@ -205,14 +177,7 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['a', 'b'],
-      },
-      submissionTimestamp: new Date().toISOString(),
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
+      }
     })
     expect(result).toBe(true)
   })
@@ -236,14 +201,7 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['a'],
-      },
-      submissionTimestamp: new Date().toISOString(),
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
+      }
     })
     expect(result).toBe(false)
   })
@@ -267,14 +225,7 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['a'],
-      },
-      submissionTimestamp: new Date().toISOString(),
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
+      }
     })
     expect(resultA).toBe(true)
 
@@ -296,14 +247,7 @@ describe('evaluateConditionalPredicates', () => {
       formElements: generateFormElements(),
       submission: {
         checkboxes: ['b'],
-      },
-      submissionTimestamp: new Date().toISOString(),
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
+      }
     })
     expect(resultB).toBe(true)
   })
@@ -649,8 +593,9 @@ describe('generateFormElementsConditionallyShown', () => {
         result.setUTCDate(result.getUTCDate() + days)
         return result
       },
+    
     })
-    expect(result).toEqual({
+    expect(result.formElementsConditionallyShown).toEqual({
       comparisonNumber: {
         isHidden: false,
         type: 'formElement',
@@ -836,8 +781,9 @@ describe('generateFormElementsConditionallyShown', () => {
         result.setUTCDate(result.getUTCDate() + days)
         return result
       },
+    
     })
-    expect(result).toEqual({
+    expect(result.formElementsConditionallyShown).toEqual({
       first_option: {
         isHidden: true,
         type: 'formElement',

--- a/tests/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.test.ts
+++ b/tests/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { ConditionTypes, FormTypes } from '@oneblink/types'
 import evaluateConditionalSubmissionTimestampPredicate from '../../src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate'
 import { evaluateConditionalPredicates } from '../../src/conditionalLogicService'
@@ -86,6 +86,30 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         addDaysToDate,
       }),
     ).toBe(false)
+  })
+
+  test('daysOffset of 0 still calls addDaysToDate', () => {
+    const addDaysToDateSpy = vi.fn(addDaysToDate)
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BEFORE',
+      compareWith: 'VALUE',
+      value: '2026-08-01',
+      daysOffset: 0,
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-15T00:00:00.000Z',
+        parseDate,
+        addDaysToDate: addDaysToDateSpy,
+      }),
+    ).toBe(true)
+
+    expect(addDaysToDateSpy).toHaveBeenCalledTimes(1)
+    expect(addDaysToDateSpy).toHaveBeenCalledWith(expect.any(Date), 0)
   })
 
   test('BEFORE with date element and daysOffset', () => {

--- a/tests/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.test.ts
+++ b/tests/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.test.ts
@@ -1,0 +1,448 @@
+import { describe, expect, test } from 'vitest'
+import { ConditionTypes, FormTypes } from '@oneblink/types'
+import evaluateConditionalSubmissionTimestampPredicate from '../../src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate'
+import { evaluateConditionalPredicates } from '../../src/conditionalLogicService'
+import { flattenFormElements } from '../../src/formElementsService'
+import { AddOffsetToDate, ParseDate } from '../../src/conditionalLogicService/types'
+
+const parseDate: ParseDate = (value) => new Date(value)
+
+const addDaysToDate: AddOffsetToDate = (date, offset) => {
+  const result = new Date(date.getTime())
+  result.setUTCDate(result.getUTCDate() + offset)
+  return result
+}
+
+
+/**
+ * Treat `YYYY-MM-DD` as the start of day in America/New_York; otherwise parse
+ * as an absolute instant.
+ */
+const parseDateInNewYork: ParseDate = (value) => {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    // EDT (UTC-4) for July test dates
+    return new Date(`${value}T04:00:00.000Z`)
+  }
+  return new Date(value)
+}
+
+describe('evaluateConditionalSubmissionTimestampPredicate', () => {
+  const dateElement: FormTypes.FormElement = {
+    id: 'agm-date-id',
+    name: 'agmDate',
+    label: 'AGM Date',
+    type: 'date',
+    required: false,
+    readOnly: false,
+    conditionallyShow: false,
+    requiresAllConditionallyShowPredicates: false,
+    isDataLookup: false,
+    isElementLookup: false,
+  }
+
+  const formElementsCtrl = {
+    flattenedElements: flattenFormElements([dateElement]),
+    model: {
+      agmDate: '2026-07-01',
+    }
+  }
+
+  test('BEFORE with custom date and daysOffset (exclusive)', () => {
+    // AGM (2026-07-01) + 30 days = 2026-07-31
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BEFORE',
+      compareWith: 'VALUE',
+      value: '2026-07-01',
+      daysOffset: 30,
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-30T12:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-31T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-08-01T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('BEFORE with date element and daysOffset', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BEFORE',
+      compareWith: 'ELEMENT',
+      formElementId: 'agm-date-id',
+      daysOffset: 30,
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-15T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-08-01T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('date element values are parsed via injected parseDate', () => {
+    // AGM 2026-07-01 + 30 days = 2026-07-31, parsed as NY start of day
+    // = 2026-07-31T04:00:00.000Z
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BEFORE',
+      compareWith: 'ELEMENT',
+      formElementId: 'agm-date-id',
+      daysOffset: 30,
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-31T03:00:00.000Z',
+        parseDate: parseDateInNewYork,
+      addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-31T04:00:00.000Z',
+        parseDate: parseDateInNewYork,
+      addDaysToDate,
+      }),
+    ).toBe(false)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-31T03:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('AFTER with custom date-only value uses parseDate', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'AFTER',
+      compareWith: 'VALUE',
+      value: '2026-07-01',
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-01T04:00:00.001Z',
+        parseDate: parseDateInNewYork,
+      addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-01T04:00:00.000Z',
+        parseDate: parseDateInNewYork,
+      addDaysToDate,
+      }),
+    ).toBe(false)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-01T03:59:59.999Z',
+        parseDate: parseDateInNewYork,
+      addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('AFTER with full ISO timestamp', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'AFTER',
+      compareWith: 'VALUE',
+      value: '2026-07-01T00:00:00.000Z',
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-01T00:00:00.001Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-01T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('AFTER with negative daysOffset', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'AFTER',
+      compareWith: 'ELEMENT',
+      formElementId: 'agm-date-id',
+      daysOffset: -14,
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-06-18T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-06-17T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('BETWEEN inclusive with custom dates', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BETWEEN',
+      min: {
+        compareWith: 'VALUE',
+        value: '2026-07-01T00:00:00.000Z',
+      },
+      max: {
+        compareWith: 'VALUE',
+        value: '2026-07-31T00:00:00.000Z',
+      },
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-01T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-15T12:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-31T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-06-30T23:59:59.999Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-31T00:00:00.001Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('BETWEEN with element and daysOffset', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BETWEEN',
+      min: {
+        compareWith: 'ELEMENT',
+        formElementId: 'agm-date-id',
+        daysOffset: -30,
+      },
+      max: {
+        compareWith: 'ELEMENT',
+        formElementId: 'agm-date-id',
+        daysOffset: -14,
+      },
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-06-10T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-05-31T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('returns false when submissionTimestamp is invalid', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BEFORE',
+      compareWith: 'VALUE',
+      value: '2026-07-01',
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: 'not-a-date',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+
+  test('returns false when comparison date element has no value', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BEFORE',
+      compareWith: 'ELEMENT',
+      formElementId: 'agm-date-id',
+    }
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl: {
+          flattenedElements: flattenFormElements([dateElement]),
+          model: {}
+        },
+        submissionTimestamp: '2026-07-15T00:00:00.000Z',
+        parseDate,
+        addDaysToDate,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('evaluateConditionalPredicates SUBMISSION_TIMESTAMP', () => {
+  test('evaluates SUBMISSION_TIMESTAMP predicates with submissionTimestamp', () => {
+    const result = evaluateConditionalPredicates({
+      isConditional: true,
+      requiresAllConditionalPredicates: false,
+      conditionalPredicates: [
+        {
+          type: 'SUBMISSION_TIMESTAMP',
+          operator: 'BEFORE',
+          compareWith: 'VALUE',
+          value: '2026-07-01',
+          daysOffset: 30,
+        },
+      ],
+      formElements: [],
+      submission: {},
+      submissionTimestamp: '2026-07-15T00:00:00.000Z',
+      parseDate,
+      addDaysToDate,
+    })
+    expect(result).toBe(true)
+  })
+
+  test('fails SUBMISSION_TIMESTAMP predicates with invalid submissionTimestamp', () => {
+    const result = evaluateConditionalPredicates({
+      isConditional: true,
+      requiresAllConditionalPredicates: false,
+      conditionalPredicates: [
+        {
+          type: 'SUBMISSION_TIMESTAMP',
+          operator: 'BEFORE',
+          compareWith: 'VALUE',
+          value: '2026-08-01',
+        },
+      ],
+      formElements: [],
+      submission: {},
+      submissionTimestamp: 'not-a-date',
+      parseDate,
+      addDaysToDate,
+    })
+    expect(result).toBe(false)
+  })
+})

--- a/tests/conditionalLogicService/evaluateFormElementConditionalPredicate.test.ts
+++ b/tests/conditionalLogicService/evaluateFormElementConditionalPredicate.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'vitest'
 import { ConditionTypes, FormTypes } from '@oneblink/types'
-import evaluateConditionalPredicate from '../../src/conditionalLogicService/evaluateConditionalPredicate'
+import evaluateFormElementConditionalPredicate from '../../src/conditionalLogicService/evaluateFormElementConditionalPredicate'
 import { flattenFormElements } from '../../src/formElementsService'
 
-describe('evaluateConditionalPredicate', () => {
+describe('evaluateFormElementConditionalPredicate', () => {
   const predicate: ConditionTypes.ConditionalPredicate = {
     elementId: 'predicateNumber',
     type: 'NUMERIC',
@@ -46,7 +46,7 @@ describe('evaluateConditionalPredicate', () => {
   }
 
   test('should show root element', () => {
-    const isShown = evaluateConditionalPredicate({
+    const isShown = evaluateFormElementConditionalPredicate({
       predicate,
       formElementsCtrl: {
         flattenedElements: [
@@ -58,13 +58,13 @@ describe('evaluateConditionalPredicate', () => {
           predicateNumber: 1,
           comparisonNumber: 1,
         },
-      },
+      }
     })
     expect(isShown).toBe(predicateElement)
   })
 
   test('should hide root element', () => {
-    const isShown = evaluateConditionalPredicate({
+    const isShown = evaluateFormElementConditionalPredicate({
       predicate,
       formElementsCtrl: {
         flattenedElements: [
@@ -76,7 +76,7 @@ describe('evaluateConditionalPredicate', () => {
           predicateNumber: 1,
           comparisonNumber: 2,
         },
-      },
+      }
     })
     expect(isShown).toBe(undefined)
   })
@@ -90,7 +90,7 @@ describe('evaluateConditionalPredicate', () => {
       conditionallyShow: false,
       elements: [conditionalElement],
     }
-    const isShown = evaluateConditionalPredicate({
+    const isShown = evaluateFormElementConditionalPredicate({
       predicate,
       formElementsCtrl: {
         flattenedElements: repeatableSetElement.elements,
@@ -106,7 +106,7 @@ describe('evaluateConditionalPredicate', () => {
             comparisonNumber: 1,
           },
         },
-      },
+      }
     })
     expect(isShown).toBe(predicateElement)
   })
@@ -154,7 +154,7 @@ describe('evaluateConditionalPredicate', () => {
       conditionallyShow: false,
       elements: [comparisonElementOne, comparisonElementTwo],
     }
-    const isShown = evaluateConditionalPredicate({
+    const isShown = evaluateFormElementConditionalPredicate({
       predicate: nestedFormPredicate,
       formElementsCtrl: {
         flattenedElements: flattenFormElements([formFormElement]),
@@ -164,7 +164,7 @@ describe('evaluateConditionalPredicate', () => {
             comparisonNumberTwo: 1,
           },
         },
-      },
+      }
     })
 
     expect(isShown).toBe(formFormElement)
@@ -226,7 +226,7 @@ describe('evaluateConditionalPredicate', () => {
       conditionallyShow: false,
       elements: [childFormFormElement],
     }
-    const isShown = evaluateConditionalPredicate({
+    const isShown = evaluateFormElementConditionalPredicate({
       predicate: formPredicate,
       formElementsCtrl: {
         flattenedElements: flattenFormElements([parentFormFormElement]),
@@ -238,7 +238,7 @@ describe('evaluateConditionalPredicate', () => {
             },
           },
         },
-      },
+      }
     })
 
     expect(isShown).toBe(parentFormFormElement)
@@ -309,7 +309,7 @@ describe('evaluateConditionalPredicate', () => {
         isDataLookup: false,
         isElementLookup: false,
       }
-      const isShown = evaluateConditionalPredicate({
+      const isShown = evaluateFormElementConditionalPredicate({
         predicate: conditionalPredicatePoint,
         formElementsCtrl: {
           flattenedElements: [predicatePoint, shownElement],
@@ -318,8 +318,8 @@ describe('evaluateConditionalPredicate', () => {
               dataset: 'mailAddress',
             },
           },
-        },
-      })
+        }
+    })
       expect(isShown).toBe(predicatePoint)
     })
     test('should show element using NSW Point V3 PO Box', () => {
@@ -335,7 +335,7 @@ describe('evaluateConditionalPredicate', () => {
         isDataLookup: false,
         isElementLookup: false,
       }
-      const isShown = evaluateConditionalPredicate({
+      const isShown = evaluateFormElementConditionalPredicate({
         predicate: conditionalPredicatePointV3,
         formElementsCtrl: {
           flattenedElements: [predicatePointV3, shownElement],
@@ -346,8 +346,8 @@ describe('evaluateConditionalPredicate', () => {
               },
             },
           },
-        },
-      })
+        }
+    })
       expect(isShown).toBe(predicatePointV3)
     })
     test('should show element using NSW Point physical address', () => {
@@ -370,7 +370,7 @@ describe('evaluateConditionalPredicate', () => {
         isDataLookup: false,
         isElementLookup: false,
       }
-      const isShown = evaluateConditionalPredicate({
+      const isShown = evaluateFormElementConditionalPredicate({
         predicate: conditionalPredicatePointNoPO,
         formElementsCtrl: {
           flattenedElements: [predicatePoint, shownElement],
@@ -379,8 +379,8 @@ describe('evaluateConditionalPredicate', () => {
               dataset: 'GNAF',
             },
           },
-        },
-      })
+        }
+    })
       expect(isShown).toBe(predicatePoint)
     })
     test('should show element using NSW Point V3 physical address', () => {
@@ -403,7 +403,7 @@ describe('evaluateConditionalPredicate', () => {
         isDataLookup: false,
         isElementLookup: false,
       }
-      const isShown = evaluateConditionalPredicate({
+      const isShown = evaluateFormElementConditionalPredicate({
         predicate: conditionalPredicatePointNoPO,
         formElementsCtrl: {
           flattenedElements: [predicatePointV3, shownElement],
@@ -412,8 +412,8 @@ describe('evaluateConditionalPredicate', () => {
               properties: { dataset: 'gnaf,mailingAddress' },
             },
           },
-        },
-      })
+        }
+    })
       expect(isShown).toBe(predicatePointV3)
     })
     test('should show element using NSW Point with states', () => {
@@ -436,7 +436,7 @@ describe('evaluateConditionalPredicate', () => {
         isDataLookup: false,
         isElementLookup: false,
       }
-      const isShown = evaluateConditionalPredicate({
+      const isShown = evaluateFormElementConditionalPredicate({
         predicate: conditionalPredicatePointStates,
         formElementsCtrl: {
           flattenedElements: [predicatePoint, shownElement],
@@ -447,8 +447,8 @@ describe('evaluateConditionalPredicate', () => {
               },
             },
           },
-        },
-      })
+        }
+    })
       expect(isShown).toBe(predicatePoint)
     })
     test('should show element using NSW Point V3 with states', () => {
@@ -471,7 +471,7 @@ describe('evaluateConditionalPredicate', () => {
         isDataLookup: false,
         isElementLookup: false,
       }
-      const isShown = evaluateConditionalPredicate({
+      const isShown = evaluateFormElementConditionalPredicate({
         predicate: conditionalPredicatePointStates,
         formElementsCtrl: {
           flattenedElements: [predicatePointV3, shownElement],
@@ -482,8 +482,8 @@ describe('evaluateConditionalPredicate', () => {
               },
             },
           },
-        },
-      })
+        }
+    })
       expect(isShown).toBe(predicatePointV3)
     })
     test('should show element using Geoscape with States', () => {
@@ -499,7 +499,7 @@ describe('evaluateConditionalPredicate', () => {
         isDataLookup: false,
         isElementLookup: false,
       }
-      const isShown = evaluateConditionalPredicate({
+      const isShown = evaluateFormElementConditionalPredicate({
         predicate: conditionalPredicateGeoscape,
         formElementsCtrl: {
           flattenedElements: [predicateGeoscape, shownElement],
@@ -510,8 +510,8 @@ describe('evaluateConditionalPredicate', () => {
               },
             },
           },
-        },
-      })
+        }
+    })
       expect(isShown).toBe(predicateGeoscape)
     })
   })

--- a/tests/conditionalLogicService/generateFormElementsConditionallyShown.test.ts
+++ b/tests/conditionalLogicService/generateFormElementsConditionallyShown.test.ts
@@ -65,8 +65,8 @@ describe('generateFormElementsConditionallyShown', () => {
   test('Dependant option element will evaluate options as "loading" when waiting for dynamic option dependencies to load and dependency has option selected', () => {
     const result = generateFormElementsConditionallyShown({
       formElements: [dynamicOptionsElement, dependantOptionsElement],
-      submission: { dynamic: 'option1' },
-    })
+      submission: { dynamic: 'option1' }
+  })
     expect(
       result.dependant?.type === 'formElement' &&
         result.dependant?.dependencyIsLoading,
@@ -76,8 +76,8 @@ describe('generateFormElementsConditionallyShown', () => {
   test('Dependant option element will evaluate options as "show" when dynamic option dependencies have not loaded but nothing selected in dependency', () => {
     const result = generateFormElementsConditionallyShown({
       formElements: [dynamicOptionsElement, dependantOptionsElement],
-      submission: {},
-    })
+      submission: {}
+  })
     expect(
       result.dependant?.type === 'formElement' &&
         result.dependant?.options?.length === 2 &&
@@ -154,8 +154,8 @@ describe('generateFormElementsConditionallyShown', () => {
       ],
       submission: {
         rs: [{ switch_one: true, switch_two: true }],
-      },
-    })
+      }
+  })
     expect(result).toEqual({
       rs: {
         type: 'repeatableSet',

--- a/tests/conditionalLogicService/generateFormElementsConditionallyShown.test.ts
+++ b/tests/conditionalLogicService/generateFormElementsConditionallyShown.test.ts
@@ -65,8 +65,9 @@ describe('generateFormElementsConditionallyShown', () => {
   test('Dependant option element will evaluate options as "loading" when waiting for dynamic option dependencies to load and dependency has option selected', () => {
     const result = generateFormElementsConditionallyShown({
       formElements: [dynamicOptionsElement, dependantOptionsElement],
-      submission: { dynamic: 'option1' }
-  })
+      submission: { dynamic: 'option1' },
+      enableSubmission: undefined,
+    })
     expect(
       result.formElementsConditionallyShown.dependant?.type === 'formElement' &&
         result.formElementsConditionallyShown.dependant?.dependencyIsLoading,
@@ -76,12 +77,15 @@ describe('generateFormElementsConditionallyShown', () => {
   test('Dependant option element will evaluate options as "show" when dynamic option dependencies have not loaded but nothing selected in dependency', () => {
     const result = generateFormElementsConditionallyShown({
       formElements: [dynamicOptionsElement, dependantOptionsElement],
-      submission: {}
-  })
+      submission: {},
+      enableSubmission: undefined,
+    })
     expect(
       result.formElementsConditionallyShown.dependant?.type === 'formElement' &&
-        result.formElementsConditionallyShown.dependant?.options?.length === 2 &&
-        result.formElementsConditionallyShown.dependant?.dependencyIsLoading === undefined,
+        result.formElementsConditionallyShown.dependant?.options?.length ===
+          2 &&
+        result.formElementsConditionallyShown.dependant?.dependencyIsLoading ===
+          undefined,
     ).toBe(true)
   })
 
@@ -154,8 +158,9 @@ describe('generateFormElementsConditionallyShown', () => {
       ],
       submission: {
         rs: [{ switch_one: true, switch_two: true }],
-      }
-  })
+      },
+      enableSubmission: undefined,
+    })
     expect(result.formElementsConditionallyShown).toEqual({
       rs: {
         type: 'repeatableSet',
@@ -177,6 +182,285 @@ describe('generateFormElementsConditionallyShown', () => {
         type: 'formElement',
         isHidden: false,
       },
+    })
+  })
+
+  test('enables submission based on a nested form element predicate', () => {
+    const nestedTextElement: FormElement = {
+      id: 'nested-text-id',
+      name: 'nested_text',
+      label: 'Nested Text',
+      type: 'text',
+      required: false,
+      conditionallyShow: false,
+      readOnly: false,
+      isDataLookup: false,
+      isElementLookup: false,
+    }
+    const nestedFormElement: FormElement = {
+      id: 'nested-form-id',
+      name: 'nested_form',
+      type: 'form',
+      formId: 1,
+      conditionallyShow: false,
+      elements: [nestedTextElement],
+    }
+
+    const enabledResult = generateFormElementsConditionallyShown({
+      formElements: [nestedFormElement],
+      submission: {
+        nested_form: {
+          nested_text: 'ready',
+        },
+      },
+      enableSubmission: {
+        requiresAllConditionalPredicates: true,
+        conditionalPredicates: [
+          {
+            elementId: 'nested-form-id',
+            type: 'FORM',
+            predicate: {
+              elementId: 'nested-text-id',
+              type: 'VALUE',
+              hasValue: true,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(enabledResult.isSubmissionEnabled).toBe(true)
+    expect(enabledResult.formElementsConditionallyShown.nested_form).toEqual({
+      type: 'formElements',
+      isHidden: false,
+      formElements: {
+        nested_text: {
+          type: 'formElement',
+          isHidden: false,
+        },
+      },
+    })
+
+    const disabledResult = generateFormElementsConditionallyShown({
+      formElements: [nestedFormElement],
+      submission: {
+        nested_form: {},
+      },
+      enableSubmission: {
+        requiresAllConditionalPredicates: true,
+        conditionalPredicates: [
+          {
+            elementId: 'nested-form-id',
+            type: 'FORM',
+            predicate: {
+              elementId: 'nested-text-id',
+              type: 'VALUE',
+              hasValue: true,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(disabledResult.isSubmissionEnabled).toBe(false)
+  })
+
+  test('enables submission based on a repeatable set element predicate', () => {
+    const nestedTextElement: FormElement = {
+      id: 'rs-text-id',
+      name: 'rs_text',
+      label: 'Repeatable Set Text',
+      type: 'text',
+      required: false,
+      conditionallyShow: false,
+      readOnly: false,
+      isDataLookup: false,
+      isElementLookup: false,
+    }
+    const repeatableSetElement: FormElement = {
+      id: 'repeatable-set-id',
+      name: 'repeatable_set',
+      label: 'Repeatable Set',
+      type: 'repeatableSet',
+      conditionallyShow: false,
+      readOnly: false,
+      elements: [nestedTextElement],
+    }
+
+    const enabledResult = generateFormElementsConditionallyShown({
+      formElements: [repeatableSetElement],
+      submission: {
+        repeatable_set: [{ rs_text: 'ready' }],
+      },
+      enableSubmission: {
+        requiresAllConditionalPredicates: true,
+        conditionalPredicates: [
+          {
+            elementId: 'repeatable-set-id',
+            type: 'REPEATABLESET',
+            repeatableSetPredicate: {
+              elementId: 'rs-text-id',
+              type: 'VALUE',
+              hasValue: true,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(enabledResult.isSubmissionEnabled).toBe(true)
+    expect(enabledResult.formElementsConditionallyShown.repeatable_set).toEqual(
+      {
+        type: 'repeatableSet',
+        isHidden: false,
+        entries: {
+          '0': {
+            rs_text: {
+              type: 'formElement',
+              isHidden: false,
+            },
+          },
+        },
+      },
+    )
+
+    const disabledResult = generateFormElementsConditionallyShown({
+      formElements: [repeatableSetElement],
+      submission: {
+        repeatable_set: [{}],
+      },
+      enableSubmission: {
+        requiresAllConditionalPredicates: true,
+        conditionalPredicates: [
+          {
+            elementId: 'repeatable-set-id',
+            type: 'REPEATABLESET',
+            repeatableSetPredicate: {
+              elementId: 'rs-text-id',
+              type: 'VALUE',
+              hasValue: true,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(disabledResult.isSubmissionEnabled).toBe(false)
+  })
+
+  test('enables submission based on an element nested in pages and sections', () => {
+    const showPageElement: FormElement = {
+      id: 'show-page-id',
+      name: 'show_page',
+      label: 'Show Page',
+      type: 'boolean',
+      required: false,
+      conditionallyShow: false,
+      readOnly: false,
+      isDataLookup: false,
+      isElementLookup: false,
+      defaultValue: false,
+    }
+    const nestedTextElement: FormElement = {
+      id: 'page-section-text-id',
+      name: 'page_section_text',
+      label: 'Page Section Text',
+      type: 'text',
+      required: false,
+      conditionallyShow: false,
+      readOnly: false,
+      isDataLookup: false,
+      isElementLookup: false,
+    }
+    const sectionElement: FormElement = {
+      id: 'section-id',
+      type: 'section',
+      label: 'Section',
+      conditionallyShow: false,
+      requiresAllConditionallyShowPredicates: false,
+      isCollapsed: false,
+      elements: [nestedTextElement],
+    }
+    const pageElement: FormElement = {
+      id: 'page-id',
+      type: 'page',
+      label: 'Page',
+      conditionallyShow: true,
+      requiresAllConditionallyShowPredicates: false,
+      conditionallyShowPredicates: [
+        {
+          elementId: 'show-page-id',
+          type: 'VALUE',
+          hasValue: true,
+        },
+      ],
+      elements: [sectionElement],
+    }
+    const formElements = [showPageElement, pageElement]
+    const enableSubmission = {
+      requiresAllConditionalPredicates: true,
+      conditionalPredicates: [
+        {
+          elementId: 'page-section-text-id',
+          type: 'VALUE' as const,
+          hasValue: true,
+        },
+      ],
+    }
+
+    const enabledResult = generateFormElementsConditionallyShown({
+      formElements,
+      submission: {
+        show_page: true,
+        page_section_text: 'ready',
+      },
+      enableSubmission,
+    })
+
+    expect(enabledResult.isSubmissionEnabled).toBe(true)
+    expect(enabledResult.formElementsConditionallyShown).toEqual({
+      show_page: {
+        type: 'formElement',
+        isHidden: false,
+      },
+      'page-id': {
+        type: 'formElement',
+        isHidden: false,
+      },
+      'section-id': {
+        type: 'formElement',
+        isHidden: false,
+      },
+      page_section_text: {
+        type: 'formElement',
+        isHidden: false,
+      },
+    })
+
+    const emptyValueResult = generateFormElementsConditionallyShown({
+      formElements,
+      submission: {
+        show_page: true,
+      },
+      enableSubmission,
+    })
+
+    expect(emptyValueResult.isSubmissionEnabled).toBe(false)
+
+    const hiddenByPageResult = generateFormElementsConditionallyShown({
+      formElements,
+      submission: {
+        page_section_text: 'ready',
+      },
+      enableSubmission,
+    })
+
+    expect(hiddenByPageResult.isSubmissionEnabled).toBe(false)
+    expect(
+      hiddenByPageResult.formElementsConditionallyShown.page_section_text,
+    ).toEqual({
+      type: 'formElement',
+      isHidden: true,
     })
   })
 })

--- a/tests/conditionalLogicService/generateFormElementsConditionallyShown.test.ts
+++ b/tests/conditionalLogicService/generateFormElementsConditionallyShown.test.ts
@@ -68,8 +68,8 @@ describe('generateFormElementsConditionallyShown', () => {
       submission: { dynamic: 'option1' }
   })
     expect(
-      result.dependant?.type === 'formElement' &&
-        result.dependant?.dependencyIsLoading,
+      result.formElementsConditionallyShown.dependant?.type === 'formElement' &&
+        result.formElementsConditionallyShown.dependant?.dependencyIsLoading,
     ).toBe(true)
   })
 
@@ -79,9 +79,9 @@ describe('generateFormElementsConditionallyShown', () => {
       submission: {}
   })
     expect(
-      result.dependant?.type === 'formElement' &&
-        result.dependant?.options?.length === 2 &&
-        result.dependant?.dependencyIsLoading === undefined,
+      result.formElementsConditionallyShown.dependant?.type === 'formElement' &&
+        result.formElementsConditionallyShown.dependant?.options?.length === 2 &&
+        result.formElementsConditionallyShown.dependant?.dependencyIsLoading === undefined,
     ).toBe(true)
   })
 
@@ -156,7 +156,7 @@ describe('generateFormElementsConditionallyShown', () => {
         rs: [{ switch_one: true, switch_two: true }],
       }
   })
-    expect(result).toEqual({
+    expect(result.formElementsConditionallyShown).toEqual({
       rs: {
         type: 'repeatableSet',
         isHidden: false,


### PR DESCRIPTION
## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Multiple documented breaking public API changes affect payment/scheduling and form-fill callers; date predicate correctness depends on caller-supplied parsing/timezone helpers.
> 
> **Overview**
> Adds **`SUBMISSION_TIMESTAMP`** conditional predicates so rules can compare the form submission time to a fixed date or a date/datetime field (with optional day offset), using **`AFTER`** / **`BEFORE`** (exclusive) or **`BETWEEN`** (inclusive). Callers must pass **`submissionTimestamp`**, **`parseDate`**, and **`addDaysToDate`** so timezone and calendar math stay under app control.
> 
> **Breaking:** **`evaluateConditionalPredicates`**, **`paymentService.checkForPaymentEvent`**, and **`schedulingService.checkForSchedulingEvent`** now require those date helpers (payment/scheduling use a single options object). **`generateFormElementsConditionallyShown`** returns **`{ formElementsConditionallyShown, isSubmissionEnabled }`**, accepts optional **`enableSubmission`**, and evaluates submission enablement using already-computed element visibility instead of a separate predicate pass.
> 
> Element-based evaluation is split into **`evaluateFormElementConditionalPredicate`** (renamed from **`evaluateConditionalPredicate`**); several internal helpers move to options-object signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 516d1abe839df1f4ebeecf86ccdd10be9b14f062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->