### PR TITLE
AP-9780 # Bumped @oneblink/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -645,7 +645,7 @@
     },
     "node_modules/@oneblink/types": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/oneblink/types.git#947d14016f0393a99338382039ace43970ac7eea",
+      "resolved": "git+ssh://git@github.com/oneblink/types.git#9d9120c0949d87b5f675a3023e3488772cd29886",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1396,9 +1396,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1958,9 +1958,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2892,9 +2892,9 @@
       }
     },
     "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4889,9 +4889,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -7530,9 +7530,9 @@
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
+++ b/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
@@ -13,7 +13,7 @@ function resolveDateValue(
   if (dateValue.compareWith === 'ELEMENT') {
     const elementAndValue = getElementAndValue(
       formElementsCtrl,
-      dateValue.formElementId,
+      dateValue.elementId,
     )
     if (typeof elementAndValue.value === 'string' && elementAndValue.value) {
       dateString = elementAndValue.value

--- a/tests/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.test.ts
+++ b/tests/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.test.ts
@@ -117,7 +117,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'BEFORE',
       compareWith: 'ELEMENT',
-      formElementId: 'agm-date-id',
+      elementId: 'agm-date-id',
       daysOffset: 30,
     }
 
@@ -149,7 +149,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'BEFORE',
       compareWith: 'ELEMENT',
-      formElementId: 'agm-date-id',
+      elementId: 'agm-date-id',
       daysOffset: 30,
     }
 
@@ -257,7 +257,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'AFTER',
       compareWith: 'ELEMENT',
-      formElementId: 'agm-date-id',
+      elementId: 'agm-date-id',
       daysOffset: -14,
     }
 
@@ -353,12 +353,12 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       operator: 'BETWEEN',
       min: {
         compareWith: 'ELEMENT',
-        formElementId: 'agm-date-id',
+        elementId: 'agm-date-id',
         daysOffset: -30,
       },
       max: {
         compareWith: 'ELEMENT',
-        formElementId: 'agm-date-id',
+        elementId: 'agm-date-id',
         daysOffset: -14,
       },
     }
@@ -408,7 +408,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'BEFORE',
       compareWith: 'ELEMENT',
-      formElementId: 'agm-date-id',
+      elementId: 'agm-date-id',
     }
 
     expect(


### PR DESCRIPTION
## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming a predicate field is a breaking contract change for any stored or API-delivered conditions still using `formElementId`; runtime logic depends on the types bump being deployed everywhere predicates are authored or migrated.
> 
> **Overview**
> Bumps **`@oneblink/types`** to commit `9d9120c` and aligns **submission timestamp** conditional predicates with the updated type shape.
> 
> When a date comparison uses **`compareWith: 'ELEMENT'`**, the predicate now reads **`elementId`** instead of **`formElementId`** in `resolveDateValue` (and in related tests for BEFORE/AFTER/BETWEEN). Behavior is unchanged aside from the property name.
> 
> `package-lock.json` also picks up minor transitive updates (e.g. `brace-expansion`, `linkify-it`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3720349272329176544d9888dbf7bcae1a1d8b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->