### PR TITLE
AP-9821 # Changed date based conditional logic to use start and end o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Support for `SUBMISSION_TIMESTAMP` predicates in `conditionalLogicService.evaluateConditionalPredicates()`. Compare the form submission timestamp to a custom date or date/datetime element, with an optional day offset, using `AFTER`/`BEFORE` (exclusive) or `BETWEEN` (inclusive). Pass required `submissionTimestamp`, `parseDate`, and `addDaysToDate` helpers when evaluating so callers control timezone-aware parsing and calendar arithmetic. Client-side code evaluating during submission should pass `new Date().toISOString()`.
+- Support for `SUBMISSION_TIMESTAMP` predicates in `conditionalLogicService.evaluateConditionalPredicates()`. Compare the form submission timestamp to a custom date or date/datetime element, with an optional day offset, using `AFTER`/`BEFORE` (exclusive) or `BETWEEN` (inclusive). Pass required `submissionTimestamp`, `parseDayOnlyDate`, `addDaysToDate`, `startOfDay`, and `endOfDay` helpers when evaluating so callers control timezone-aware calendar arithmetic. sdk-core only calls `parseDayOnlyDate` for `YYYY-MM-DD` values; other date strings use `new Date(value)`. Client-side code evaluating during submission should pass `new Date().toISOString()`.
+- For day-only (`YYYY-MM-DD`) comparison values, day boundaries are applied: `AFTER` uses end of day, `BEFORE` uses start of day, and `BETWEEN` uses start of `min` through end of `max`. Full ISO datetime values compare at the exact instant.
 
 ### Changed
 
-- **[BREAKING]** `evaluateConditionalPredicates()` now requires `submissionTimestamp: string`, `parseDate: (value: string) => Date`, and `addDaysToDate: (date: Date, offset: number) => Date`.
-- **[BREAKING]** `paymentService.checkForPaymentEvent()` and `schedulingService.checkForSchedulingEvent()` now take a single options object (`{ definition, submission, submissionTimestamp, parseDate, addDaysToDate }`).
+- **[BREAKING]** `evaluateConditionalPredicates()` now requires `submissionTimestamp: string`, `parseDayOnlyDate: (value: string) => Date`, `addDaysToDate: (date: Date, offset: number) => Date`, `startOfDay: (date: Date) => Date`, and `endOfDay: (date: Date) => Date`.
+- **[BREAKING]** `paymentService.checkForPaymentEvent()` and `schedulingService.checkForSchedulingEvent()` now take a single options object (`{ definition, submission, submissionTimestamp, parseDayOnlyDate, addDaysToDate, startOfDay, endOfDay }`).
 - **[BREAKING]** `generateFormElementsConditionallyShown()` now returns `{ formElementsConditionallyShown, isSubmissionEnabled }` and accepts optional `enableSubmission`. Form-fill submission enablement is evaluated here (visibility-aware) instead of a separate `evaluateConditionalPredicates()` call.
 
 ## [9.2.2] - 2026-07-09

--- a/src/conditionalLogicService.ts
+++ b/src/conditionalLogicService.ts
@@ -2,10 +2,20 @@ import evaluateFormElementConditionalPredicate from './conditionalLogicService/e
 import evaluateConditionalSubmissionTimestampPredicate from './conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.js'
 import { flattenFormElements } from './formElementsService.js'
 import { ConditionTypes, FormTypes, SubmissionTypes } from '@oneblink/types'
-import { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
+import {
+  AddOffsetToDate,
+  EndOfDay,
+  ParseDayOnlyDate,
+  StartOfDay,
+} from './conditionalLogicService/types.js'
 
 export * from './conditionalLogicService/generateFormElementsConditionallyShown.js'
-export type { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
+export type {
+  AddOffsetToDate,
+  EndOfDay,
+  ParseDayOnlyDate,
+  StartOfDay,
+} from './conditionalLogicService/types.js'
 
 /**
  * Given a set of form elements and submission data, evaluate if predicates are
@@ -63,9 +73,17 @@ export type { AddOffsetToDate, ParseDate } from './conditionalLogicService/types
  *       },
  *     ],
  *     submissionTimestamp: new Date().toISOString(),
- *     parseDate: (value) => new Date(value),
+ *     parseDayOnlyDate: (value) => new Date(`${value}T00:00:00.000Z`),
  *     addDaysToDate: (date, days) => {
  *       date.setUTCDate(date.getUTCDate() + days)
+ *       return date
+ *     },
+ *     startOfDay: (date) => {
+ *       date.setUTCHours(0, 0, 0, 0)
+ *       return date
+ *     },
+ *     endOfDay: (date) => {
+ *       date.setUTCHours(23, 59, 59, 999)
  *       return date
  *     },
  *   },
@@ -82,8 +100,10 @@ export function evaluateConditionalPredicates({
   formElements,
   submission,
   submissionTimestamp,
-  parseDate,
+  parseDayOnlyDate,
   addDaysToDate,
+  startOfDay,
+  endOfDay,
 }: {
   isConditional: boolean
   requiresAllConditionalPredicates: boolean
@@ -92,10 +112,14 @@ export function evaluateConditionalPredicates({
   submission: SubmissionTypes.S3SubmissionData['submission']
   /** ISO timestamp the form was submitted. When evaluating during submission, pass `new Date().toISOString()`. */
   submissionTimestamp: string
-  /** Parse date/datetime strings when evaluating date based predicates */
-  parseDate: ParseDate
+  /** Parse `YYYY-MM-DD` strings when evaluating date based predicates */
+  parseDayOnlyDate: ParseDayOnlyDate
   /** Add days to a date when evaluating date based predicates */
   addDaysToDate: AddOffsetToDate
+  /** Start of calendar day when evaluating date (not datetime) based predicates */
+  startOfDay: StartOfDay
+  /** End of calendar day when evaluating date (not datetime) based predicates */
+  endOfDay: EndOfDay
 }): boolean {
   if (!isConditional || !conditionalPredicates.length) {
     return true
@@ -111,8 +135,10 @@ export function evaluateConditionalPredicates({
         predicate,
         formElementsCtrl,
         submissionTimestamp,
-        parseDate,
+        parseDayOnlyDate,
         addDaysToDate,
+        startOfDay,
+        endOfDay,
       })
     }
 

--- a/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
+++ b/src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.ts
@@ -1,12 +1,25 @@
 import { ConditionTypes } from '@oneblink/types'
-import { AddOffsetToDate, FormElementsCtrl, ParseDate } from './types.js'
+import {
+  AddOffsetToDate,
+  EndOfDay,
+  FormElementsCtrl,
+  ParseDayOnlyDate,
+  StartOfDay,
+} from './types.js'
 import { getElementAndValue } from './evaluateFormElementConditionalPredicate.js'
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+type DayBoundary = 'start' | 'end'
 
 function resolveDateValue(
   dateValue: ConditionTypes.ConditionalPredicateDateValue,
   formElementsCtrl: FormElementsCtrl,
-  parseDate: ParseDate,
+  parseDayOnlyDate: ParseDayOnlyDate,
   addDaysToDate: AddOffsetToDate,
+  startOfDay: StartOfDay,
+  endOfDay: EndOfDay,
+  dayBoundary: DayBoundary,
 ): Date | undefined {
   let dateString: string | undefined
 
@@ -17,27 +30,34 @@ function resolveDateValue(
     )
     if (typeof elementAndValue.value === 'string' && elementAndValue.value) {
       dateString = elementAndValue.value
-    }
-    if (!dateString) {
+    } else {
       return undefined
     }
   } else {
     dateString = dateValue.value
   }
 
-  const date = parseDate(dateString)
+  const isDayOnly = DATE_ONLY_PATTERN.test(dateString)
+  const date = isDayOnly ? parseDayOnlyDate(dateString) : new Date(dateString)
   if (Number.isNaN(date.getTime())) {
     return undefined
   }
 
-  if (
+  const dateWithOffset =
     typeof dateValue.daysOffset !== 'number' ||
     Number.isNaN(dateValue.daysOffset)
-  ) {
-    return date
+      ? date
+      : addDaysToDate(date, dateValue.daysOffset)
+
+  if (isDayOnly) {
+    if (dayBoundary === 'start') {
+      return startOfDay(dateWithOffset)
+    } else {
+      return endOfDay(dateWithOffset)
+    }
   }
 
-  return addDaysToDate(date, dateValue.daysOffset)
+  return dateWithOffset
 }
 
 /**
@@ -48,21 +68,35 @@ function resolveDateValue(
  * - `BEFORE` — submission timestamp is before (exclusive) the comparison date
  * - `BETWEEN` — submission timestamp is between `min` and `max` (inclusive)
  *
- * Date strings are parsed via `parseDate`. Day offsets are applied via
+ * When the comparison value is a day-only (`YYYY-MM-DD`) string, day
+ * boundaries are applied via the injected helpers:
+ *
+ * - `AFTER` — end of the comparison day
+ * - `BEFORE` — start of the comparison day
+ * - `BETWEEN` — start of `min` day through end of `max` day
+ *
+ * Full ISO datetime values compare at the exact instant.
+ *
+ * Day-only (`YYYY-MM-DD`) strings are parsed via `parseDayOnlyDate`. Other
+ * date strings use `new Date(value)`. Day offsets are applied via
  * `addDaysToDate(date, offset)`.
  */
 export default function evaluateConditionalSubmissionTimestampPredicate({
   predicate,
   formElementsCtrl,
   submissionTimestamp,
-  parseDate,
+  parseDayOnlyDate,
   addDaysToDate,
+  startOfDay,
+  endOfDay,
 }: {
   predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp
   formElementsCtrl: FormElementsCtrl
   submissionTimestamp: string
-  parseDate: ParseDate
+  parseDayOnlyDate: ParseDayOnlyDate
   addDaysToDate: AddOffsetToDate
+  startOfDay: StartOfDay
+  endOfDay: EndOfDay
 }): boolean {
   const submissionDate = new Date(submissionTimestamp)
   if (Number.isNaN(submissionDate.getTime())) {
@@ -76,14 +110,20 @@ export default function evaluateConditionalSubmissionTimestampPredicate({
       const min = resolveDateValue(
         predicate.min,
         formElementsCtrl,
-        parseDate,
+        parseDayOnlyDate,
         addDaysToDate,
+        startOfDay,
+        endOfDay,
+        'start',
       )
       const max = resolveDateValue(
         predicate.max,
         formElementsCtrl,
-        parseDate,
+        parseDayOnlyDate,
         addDaysToDate,
+        startOfDay,
+        endOfDay,
+        'end',
       )
       if (!min || !max) {
         return false
@@ -91,11 +131,16 @@ export default function evaluateConditionalSubmissionTimestampPredicate({
       return submissionTime >= min.getTime() && submissionTime <= max.getTime()
     }
     default: {
+      const dayBoundary: DayBoundary =
+        predicate.operator === 'AFTER' ? 'end' : 'start'
       const compareDate = resolveDateValue(
         predicate,
         formElementsCtrl,
-        parseDate,
+        parseDayOnlyDate,
         addDaysToDate,
+        startOfDay,
+        endOfDay,
+        dayBoundary,
       )
       if (!compareDate) {
         return false

--- a/src/conditionalLogicService/types.ts
+++ b/src/conditionalLogicService/types.ts
@@ -1,16 +1,30 @@
 import { FormTypes, SubmissionTypes } from '@oneblink/types'
 
 /**
- * Parse a date/datetime string into a `Date`. Callers supply timezone-aware
- * parsing (e.g. treating `YYYY-MM-DD` as the start of day in an organisation
- * timezone).
+ * Parse a day-only (`YYYY-MM-DD`) string into a `Date`. Callers supply
+ * timezone-aware parsing (e.g. start of day in an organisation timezone).
+ * sdk-core only invokes this for values that match `YYYY-MM-DD`.
  */
-export type ParseDate = (value: string) => Date
+export type ParseDayOnlyDate = (value: string) => Date
 
 /**
  * Add an offset to a date. Callers supply timezone-aware calendar arithmetic.
  */
 export type AddOffsetToDate = (date: Date, offset: number) => Date
+
+/**
+ * Move a date to the start of its calendar day. Callers supply timezone-aware
+ * behaviour (e.g. organisation timezone on the server, local timezone in the
+ * browser).
+ */
+export type StartOfDay = (date: Date) => Date
+
+/**
+ * Move a date to the end of its calendar day (last millisecond). Callers supply
+ * timezone-aware behaviour (e.g. organisation timezone on the server, local
+ * timezone in the browser).
+ */
+export type EndOfDay = (date: Date) => Date
 
 export type FormElementsCtrl = {
   model: SubmissionTypes.S3SubmissionData['submission'] | undefined

--- a/src/paymentService.ts
+++ b/src/paymentService.ts
@@ -8,7 +8,12 @@ import {
   getRootElementValueById,
   ReplaceInjectablesFormatters,
 } from './submissionService.js'
-import { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
+import {
+  AddOffsetToDate,
+  EndOfDay,
+  ParseDayOnlyDate,
+  StartOfDay,
+} from './conditionalLogicService/types.js'
 
 /**
  * Examine a submission and its form definition to validate whether a payment
@@ -21,9 +26,17 @@ import { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
  *   definition: form,
  *   submission,
  *   submissionTimestamp,
- *   parseDate: (value) => new Date(value),
+ *   parseDayOnlyDate: (value) => new Date(`${value}T00:00:00.000Z`),
  *   addDaysToDate: (date, days) => {
  *     date.setUTCDate(date.getUTCDate() + days)
+ *     return date
+ *   },
+ *   startOfDay: (date) => {
+ *     date.setUTCHours(0, 0, 0, 0)
+ *     return date
+ *   },
+ *   endOfDay: (date) => {
+ *     date.setUTCHours(23, 59, 59, 999)
  *     return date
  *   },
  * })
@@ -36,17 +49,23 @@ export function checkForPaymentEvent({
   definition,
   submission,
   submissionTimestamp,
-  parseDate,
+  parseDayOnlyDate,
   addDaysToDate,
+  startOfDay,
+  endOfDay,
 }: {
   definition: FormTypes.Form
   submission: SubmissionTypes.S3SubmissionData['submission']
   /** ISO timestamp the form was submitted. When evaluating during submission, pass `new Date().toISOString()`. */
   submissionTimestamp: string
-  /** Parse date/datetime strings when evaluating date based predicates */
-  parseDate: ParseDate
+  /** Parse `YYYY-MM-DD` strings when evaluating date based predicates */
+  parseDayOnlyDate: ParseDayOnlyDate
   /** Add days to a date when evaluating date based predicates */
   addDaysToDate: AddOffsetToDate
+  /** Start of calendar day when evaluating date (not datetime) based predicates */
+  startOfDay: StartOfDay
+  /** End of calendar day when evaluating date (not datetime) based predicates */
+  endOfDay: EndOfDay
 }):
   | {
       paymentSubmissionEvent: SubmissionEventTypes.FormPaymentEvent
@@ -67,8 +86,10 @@ export function checkForPaymentEvent({
           submission: submission,
           formElements: definition.elements,
           submissionTimestamp,
-          parseDate,
+          parseDayOnlyDate,
           addDaysToDate,
+          startOfDay,
+          endOfDay,
         })
       )
     },

--- a/src/schedulingService.ts
+++ b/src/schedulingService.ts
@@ -4,7 +4,12 @@ import {
   SubmissionTypes,
 } from '@oneblink/types'
 import { conditionalLogicService } from './index.js'
-import { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
+import {
+  AddOffsetToDate,
+  EndOfDay,
+  ParseDayOnlyDate,
+  StartOfDay,
+} from './conditionalLogicService/types.js'
 
 /**
  * Examine a submission and its form definition to validate whether a scheduling
@@ -17,9 +22,17 @@ import { AddOffsetToDate, ParseDate } from './conditionalLogicService/types.js'
  *   definition: form,
  *   submission,
  *   submissionTimestamp,
- *   parseDate: (value) => new Date(value),
+ *   parseDayOnlyDate: (value) => new Date(`${value}T00:00:00.000Z`),
  *   addDaysToDate: (date, days) => {
  *     date.setUTCDate(date.getUTCDate() + days)
+ *     return date
+ *   },
+ *   startOfDay: (date) => {
+ *     date.setUTCHours(0, 0, 0, 0)
+ *     return date
+ *   },
+ *   endOfDay: (date) => {
+ *     date.setUTCHours(23, 59, 59, 999)
  *     return date
  *   },
  * })
@@ -32,17 +45,23 @@ export function checkForSchedulingEvent({
   definition,
   submission,
   submissionTimestamp,
-  parseDate,
+  parseDayOnlyDate,
   addDaysToDate,
+  startOfDay,
+  endOfDay,
 }: {
   definition: FormTypes.Form
   submission: SubmissionTypes.S3SubmissionData['submission']
   /** ISO timestamp the form was submitted. When evaluating during submission, pass `new Date().toISOString()`. */
   submissionTimestamp: string
-  /** Parse date/datetime strings when evaluating date based predicates */
-  parseDate: ParseDate
+  /** Parse `YYYY-MM-DD` strings when evaluating date based predicates */
+  parseDayOnlyDate: ParseDayOnlyDate
   /** Add days to a date when evaluating date based predicates */
   addDaysToDate: AddOffsetToDate
+  /** Start of calendar day when evaluating date (not datetime) based predicates */
+  startOfDay: StartOfDay
+  /** End of calendar day when evaluating date (not datetime) based predicates */
+  endOfDay: EndOfDay
 }): SubmissionEventTypes.FormSchedulingEvent | undefined {
   const schedulingSubmissionEvents = definition.schedulingEvents || []
   return schedulingSubmissionEvents.find((schedulingSubmissionEvent) =>
@@ -55,8 +74,10 @@ export function checkForSchedulingEvent({
       submission: submission,
       formElements: definition.elements,
       submissionTimestamp,
-      parseDate,
+      parseDayOnlyDate,
       addDaysToDate,
+      startOfDay,
+      endOfDay,
     }),
   )
 }

--- a/tests/conditionalLogicService.test.ts
+++ b/tests/conditionalLogicService.test.ts
@@ -587,13 +587,6 @@ describe('generateFormElementsConditionallyShown', () => {
           ],
         },
       ],
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
-    
     })
     expect(result.formElementsConditionallyShown).toEqual({
       comparisonNumber: {
@@ -775,13 +768,6 @@ describe('generateFormElementsConditionallyShown', () => {
         },
       ],
       errorCallback,
-      parseDate: (value) => new Date(value),
-      addDaysToDate: (date, days) => {
-        const result = new Date(date.getTime())
-        result.setUTCDate(result.getUTCDate() + days)
-        return result
-      },
-    
     })
     expect(result.formElementsConditionallyShown).toEqual({
       first_option: {

--- a/tests/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.test.ts
+++ b/tests/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate.test.ts
@@ -3,9 +3,15 @@ import { ConditionTypes, FormTypes } from '@oneblink/types'
 import evaluateConditionalSubmissionTimestampPredicate from '../../src/conditionalLogicService/evaluateConditionalSubmissionTimestampPredicate'
 import { evaluateConditionalPredicates } from '../../src/conditionalLogicService'
 import { flattenFormElements } from '../../src/formElementsService'
-import { AddOffsetToDate, ParseDate } from '../../src/conditionalLogicService/types'
+import {
+  AddOffsetToDate,
+  EndOfDay,
+  ParseDayOnlyDate,
+  StartOfDay,
+} from '../../src/conditionalLogicService/types'
 
-const parseDate: ParseDate = (value) => new Date(value)
+const parseDayOnlyDate: ParseDayOnlyDate = (value) =>
+  new Date(`${value}T00:00:00.000Z`)
 
 const addDaysToDate: AddOffsetToDate = (date, offset) => {
   const result = new Date(date.getTime())
@@ -13,17 +19,41 @@ const addDaysToDate: AddOffsetToDate = (date, offset) => {
   return result
 }
 
+const startOfDay: StartOfDay = (date) => {
+  const result = new Date(date.getTime())
+  result.setUTCHours(0, 0, 0, 0)
+  return result
+}
 
-/**
- * Treat `YYYY-MM-DD` as the start of day in America/New_York; otherwise parse
- * as an absolute instant.
- */
-const parseDateInNewYork: ParseDate = (value) => {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    // EDT (UTC-4) for July test dates
-    return new Date(`${value}T04:00:00.000Z`)
-  }
-  return new Date(value)
+const endOfDay: EndOfDay = (date) => {
+  const result = new Date(date.getTime())
+  result.setUTCHours(23, 59, 59, 999)
+  return result
+}
+
+/** Treat `YYYY-MM-DD` as the start of day in America/New_York (EDT for July). */
+const parseDayOnlyDateInNewYork: ParseDayOnlyDate = (value) =>
+  new Date(`${value}T04:00:00.000Z`)
+
+/** NY midnight is already encoded by `parseDayOnlyDateInNewYork` for July dates. */
+const startOfDayInNewYork: StartOfDay = (date) => new Date(date.getTime())
+
+/** End of NY day for July (EDT) test dates: start + 24h - 1ms. */
+const endOfDayInNewYork: EndOfDay = (date) =>
+  new Date(date.getTime() + 24 * 60 * 60 * 1000 - 1)
+
+const dateHelpers = {
+  parseDayOnlyDate,
+  addDaysToDate,
+  startOfDay,
+  endOfDay,
+}
+
+const newYorkDateHelpers = {
+  parseDayOnlyDate: parseDayOnlyDateInNewYork,
+  addDaysToDate,
+  startOfDay: startOfDayInNewYork,
+  endOfDay: endOfDayInNewYork,
 }
 
 describe('evaluateConditionalSubmissionTimestampPredicate', () => {
@@ -40,15 +70,35 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
     isElementLookup: false,
   }
 
+  const datetimeElement: FormTypes.FormElement = {
+    id: 'agm-datetime-id',
+    name: 'agmDateTime',
+    label: 'AGM Date Time',
+    type: 'datetime',
+    required: false,
+    readOnly: false,
+    conditionallyShow: false,
+    requiresAllConditionallyShowPredicates: false,
+    isDataLookup: false,
+    isElementLookup: false,
+  }
+
   const formElementsCtrl = {
     flattenedElements: flattenFormElements([dateElement]),
     model: {
       agmDate: '2026-07-01',
-    }
+    },
   }
 
-  test('BEFORE with custom date and daysOffset (exclusive)', () => {
-    // AGM (2026-07-01) + 30 days = 2026-07-31
+  const datetimeFormElementsCtrl = {
+    flattenedElements: flattenFormElements([datetimeElement]),
+    model: {
+      agmDateTime: '2026-07-01T12:00:00.000Z',
+    },
+  }
+
+  test('BEFORE with custom date and daysOffset uses start of day (exclusive)', () => {
+    // AGM (2026-07-01) + 30 days = 2026-07-31 start of day
     const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'BEFORE',
@@ -62,8 +112,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-30T12:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(true)
 
@@ -72,8 +121,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-31T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(false)
 
@@ -82,8 +130,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-08-01T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(false)
   })
@@ -103,7 +150,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-15T00:00:00.000Z',
-        parseDate,
+        ...dateHelpers,
         addDaysToDate: addDaysToDateSpy,
       }),
     ).toBe(true)
@@ -112,7 +159,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
     expect(addDaysToDateSpy).toHaveBeenCalledWith(expect.any(Date), 0)
   })
 
-  test('BEFORE with date element and daysOffset', () => {
+  test('BEFORE with date element and daysOffset uses start of day', () => {
     const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'BEFORE',
@@ -126,8 +173,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-15T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(true)
 
@@ -136,13 +182,12 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-08-01T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(false)
   })
 
-  test('date element values are parsed via injected parseDate', () => {
+  test('date element values are parsed via injected parseDayOnlyDate with timezone start of day', () => {
     // AGM 2026-07-01 + 30 days = 2026-07-31, parsed as NY start of day
     // = 2026-07-31T04:00:00.000Z
     const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
@@ -158,8 +203,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-31T03:00:00.000Z',
-        parseDate: parseDateInNewYork,
-      addDaysToDate,
+        ...newYorkDateHelpers,
       }),
     ).toBe(true)
 
@@ -168,8 +212,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-31T04:00:00.000Z',
-        parseDate: parseDateInNewYork,
-      addDaysToDate,
+        ...newYorkDateHelpers,
       }),
     ).toBe(false)
 
@@ -178,66 +221,107 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-31T03:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(false)
   })
 
-  test('AFTER with custom date-only value uses parseDate', () => {
+  test('AFTER with date-only value uses end of day', () => {
     const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'AFTER',
       compareWith: 'VALUE',
       value: '2026-07-01',
     }
+    const startOfDaySpy = vi.fn(startOfDay)
+    const endOfDaySpy = vi.fn(endOfDay)
 
+    // Still on 2026-07-01 — not after end of day
     expect(
       evaluateConditionalSubmissionTimestampPredicate({
         predicate,
         formElementsCtrl,
-        submissionTimestamp: '2026-07-01T04:00:00.001Z',
-        parseDate: parseDateInNewYork,
-      addDaysToDate,
+        submissionTimestamp: '2026-07-01T12:00:00.000Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
+      }),
+    ).toBe(false)
+
+    // Exactly end of day — exclusive, so false
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-01T23:59:59.999Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
+      }),
+    ).toBe(false)
+
+    // After end of day
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-02T00:00:00.000Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
       }),
     ).toBe(true)
 
-    expect(
-      evaluateConditionalSubmissionTimestampPredicate({
-        predicate,
-        formElementsCtrl,
-        submissionTimestamp: '2026-07-01T04:00:00.000Z',
-        parseDate: parseDateInNewYork,
-      addDaysToDate,
-      }),
-    ).toBe(false)
-
-    expect(
-      evaluateConditionalSubmissionTimestampPredicate({
-        predicate,
-        formElementsCtrl,
-        submissionTimestamp: '2026-07-01T03:59:59.999Z',
-        parseDate: parseDateInNewYork,
-      addDaysToDate,
-      }),
-    ).toBe(false)
+    expect(endOfDaySpy).toHaveBeenCalled()
+    expect(startOfDaySpy).not.toHaveBeenCalled()
   })
 
-  test('AFTER with full ISO timestamp', () => {
+  test('AFTER with date element uses end of day in organisation timezone', () => {
+    // 2026-07-01 NY end of day = 2026-07-02T03:59:59.999Z
     const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'AFTER',
-      compareWith: 'VALUE',
-      value: '2026-07-01T00:00:00.000Z',
+      compareWith: 'ELEMENT',
+      elementId: 'agm-date-id',
     }
 
     expect(
       evaluateConditionalSubmissionTimestampPredicate({
         predicate,
         formElementsCtrl,
+        submissionTimestamp: '2026-07-02T03:59:59.999Z',
+        ...newYorkDateHelpers,
+      }),
+    ).toBe(false)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-02T04:00:00.000Z',
+        ...newYorkDateHelpers,
+      }),
+    ).toBe(true)
+  })
+
+  test('AFTER with full ISO timestamp compares exact instant', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'AFTER',
+      compareWith: 'VALUE',
+      value: '2026-07-01T00:00:00.000Z',
+    }
+    const parseDayOnlyDateSpy = vi.fn(parseDayOnlyDate)
+    const endOfDaySpy = vi.fn(endOfDay)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
         submissionTimestamp: '2026-07-01T00:00:00.001Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
+        parseDayOnlyDate: parseDayOnlyDateSpy,
+        endOfDay: endOfDaySpy,
       }),
     ).toBe(true)
 
@@ -246,13 +330,50 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-01T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
+        parseDayOnlyDate: parseDayOnlyDateSpy,
+        endOfDay: endOfDaySpy,
       }),
     ).toBe(false)
+
+    expect(parseDayOnlyDateSpy).not.toHaveBeenCalled()
+    expect(endOfDaySpy).not.toHaveBeenCalled()
   })
 
-  test('AFTER with negative daysOffset', () => {
+  test('AFTER with datetime element compares exact instant', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'AFTER',
+      compareWith: 'ELEMENT',
+      elementId: 'agm-datetime-id',
+    }
+    const endOfDaySpy = vi.fn(endOfDay)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl: datetimeFormElementsCtrl,
+        submissionTimestamp: '2026-07-01T12:00:00.001Z',
+        ...dateHelpers,
+        endOfDay: endOfDaySpy,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl: datetimeFormElementsCtrl,
+        submissionTimestamp: '2026-07-01T12:00:00.000Z',
+        ...dateHelpers,
+        endOfDay: endOfDaySpy,
+      }),
+    ).toBe(false)
+
+    expect(endOfDaySpy).not.toHaveBeenCalled()
+  })
+
+  test('AFTER with negative daysOffset uses end of day for date element', () => {
+    // 2026-07-01 - 14 days = 2026-06-17 end of day
     const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'AFTER',
@@ -265,9 +386,45 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       evaluateConditionalSubmissionTimestampPredicate({
         predicate,
         formElementsCtrl,
+        submissionTimestamp: '2026-06-17T12:00:00.000Z',
+        ...dateHelpers,
+      }),
+    ).toBe(false)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
         submissionTimestamp: '2026-06-18T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
+      }),
+    ).toBe(true)
+  })
+
+  test('BETWEEN inclusive uses start of min day and end of max day for date-only values', () => {
+    const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
+      type: 'SUBMISSION_TIMESTAMP',
+      operator: 'BETWEEN',
+      min: {
+        compareWith: 'VALUE',
+        value: '2026-07-01',
+      },
+      max: {
+        compareWith: 'VALUE',
+        value: '2026-07-31',
+      },
+    }
+    const startOfDaySpy = vi.fn(startOfDay)
+    const endOfDaySpy = vi.fn(endOfDay)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-01T00:00:00.000Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
       }),
     ).toBe(true)
 
@@ -275,14 +432,51 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       evaluateConditionalSubmissionTimestampPredicate({
         predicate,
         formElementsCtrl,
-        submissionTimestamp: '2026-06-17T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        submissionTimestamp: '2026-07-15T12:00:00.000Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-07-31T23:59:59.999Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-06-30T23:59:59.999Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
       }),
     ).toBe(false)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-08-01T00:00:00.000Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
+      }),
+    ).toBe(false)
+
+    expect(startOfDaySpy).toHaveBeenCalled()
+    expect(endOfDaySpy).toHaveBeenCalled()
   })
 
-  test('BETWEEN inclusive with custom dates', () => {
+  test('BETWEEN with datetime ISO bounds compares exact instants', () => {
     const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'BETWEEN',
@@ -295,34 +489,17 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         value: '2026-07-31T00:00:00.000Z',
       },
     }
-
-    expect(
-      evaluateConditionalSubmissionTimestampPredicate({
-        predicate,
-        formElementsCtrl,
-        submissionTimestamp: '2026-07-01T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
-      }),
-    ).toBe(true)
-
-    expect(
-      evaluateConditionalSubmissionTimestampPredicate({
-        predicate,
-        formElementsCtrl,
-        submissionTimestamp: '2026-07-15T12:00:00.000Z',
-        parseDate,
-        addDaysToDate,
-      }),
-    ).toBe(true)
+    const startOfDaySpy = vi.fn(startOfDay)
+    const endOfDaySpy = vi.fn(endOfDay)
 
     expect(
       evaluateConditionalSubmissionTimestampPredicate({
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-07-31T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
       }),
     ).toBe(true)
 
@@ -330,24 +507,20 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       evaluateConditionalSubmissionTimestampPredicate({
         predicate,
         formElementsCtrl,
-        submissionTimestamp: '2026-06-30T23:59:59.999Z',
-        parseDate,
-        addDaysToDate,
+        submissionTimestamp: '2026-07-31T00:00:00.001Z',
+        ...dateHelpers,
+        startOfDay: startOfDaySpy,
+        endOfDay: endOfDaySpy,
       }),
     ).toBe(false)
 
-    expect(
-      evaluateConditionalSubmissionTimestampPredicate({
-        predicate,
-        formElementsCtrl,
-        submissionTimestamp: '2026-07-31T00:00:00.001Z',
-        parseDate,
-        addDaysToDate,
-      }),
-    ).toBe(false)
+    expect(startOfDaySpy).not.toHaveBeenCalled()
+    expect(endOfDaySpy).not.toHaveBeenCalled()
   })
 
-  test('BETWEEN with element and daysOffset', () => {
+  test('BETWEEN with element and daysOffset uses day boundaries', () => {
+    // min: 2026-07-01 - 30 = 2026-06-01 start
+    // max: 2026-07-01 - 14 = 2026-06-17 end
     const predicate: ConditionTypes.ConditionalPredicateSubmissionTimestamp = {
       type: 'SUBMISSION_TIMESTAMP',
       operator: 'BETWEEN',
@@ -368,8 +541,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: '2026-06-10T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(true)
 
@@ -377,9 +549,26 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
       evaluateConditionalSubmissionTimestampPredicate({
         predicate,
         formElementsCtrl,
+        submissionTimestamp: '2026-06-17T23:59:59.999Z',
+        ...dateHelpers,
+      }),
+    ).toBe(true)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
+        submissionTimestamp: '2026-06-18T00:00:00.000Z',
+        ...dateHelpers,
+      }),
+    ).toBe(false)
+
+    expect(
+      evaluateConditionalSubmissionTimestampPredicate({
+        predicate,
+        formElementsCtrl,
         submissionTimestamp: '2026-05-31T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(false)
   })
@@ -397,8 +586,7 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl,
         submissionTimestamp: 'not-a-date',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(false)
   })
@@ -416,11 +604,10 @@ describe('evaluateConditionalSubmissionTimestampPredicate', () => {
         predicate,
         formElementsCtrl: {
           flattenedElements: flattenFormElements([dateElement]),
-          model: {}
+          model: {},
         },
         submissionTimestamp: '2026-07-15T00:00:00.000Z',
-        parseDate,
-        addDaysToDate,
+        ...dateHelpers,
       }),
     ).toBe(false)
   })
@@ -443,8 +630,7 @@ describe('evaluateConditionalPredicates SUBMISSION_TIMESTAMP', () => {
       formElements: [],
       submission: {},
       submissionTimestamp: '2026-07-15T00:00:00.000Z',
-      parseDate,
-      addDaysToDate,
+      ...dateHelpers,
     })
     expect(result).toBe(true)
   })
@@ -464,8 +650,7 @@ describe('evaluateConditionalPredicates SUBMISSION_TIMESTAMP', () => {
       formElements: [],
       submission: {},
       submissionTimestamp: 'not-a-date',
-      parseDate,
-      addDaysToDate,
+      ...dateHelpers,
     })
     expect(result).toBe(false)
   })


### PR DESCRIPTION
…f day

## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API and changed semantics for payment/scheduling conditional execution can alter which workflow events run for existing forms.
> 
> **Overview**
> **SUBMISSION_TIMESTAMP** predicates now treat **`YYYY-MM-DD`** comparison values as whole calendar days instead of a single parsed instant. **`AFTER`** compares against **end of day**, **`BEFORE`** against **start of day**, and **`BETWEEN`** uses **start of `min`** through **end of `max`** (inclusive). Full ISO datetime strings still compare at the exact instant; non–day-only values use **`new Date(value)`** and skip day-boundary helpers.
> 
> This is a **breaking** API change: **`parseDate`** is replaced by **`parseDayOnlyDate`** (invoked only for **`YYYY-MM-DD`**), and callers must supply **`startOfDay`** and **`endOfDay`** alongside **`addDaysToDate`**. **`evaluateConditionalPredicates`**, **`paymentService.checkForPaymentEvent`**, and **`schedulingService.checkForSchedulingEvent`** all require the updated options object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3fdaf39ac708d13842e5ed2375f4b0a5d1af5bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->