### PR TITLE
AP-9991 # Added `formElementsService.injectFormElementsIntoForms()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `formElementsService.injectFormElementsIntoForms()` which takes an array of forms and a `getForm(formId)` callback, mutates each form in place, and caches retrieved forms by id across the whole batch.
+
 ### Added
 
 - `paymentService.getFormStorePaymentFromFormSubmissionPayment()` to map a form submission payment to Form Store payment fields (`status`, `providerTransactionId`, `providerReceiptNumber`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
-
-- `formElementsService.injectFormElementsIntoForms()` which takes an array of forms and a `getForm(formId)` callback, mutates each form in place, and caches retrieved forms by id across the whole batch.
-
 ### Added
 
+- `formElementsService.injectFormElementsIntoForms()` which takes an array of forms and a `getForm(formId)` callback, mutates each form in place, and caches retrieved forms by id across the whole batch.
 - `paymentService.getFormStorePaymentFromFormSubmissionPayment()` to map a form submission payment to Form Store payment fields (`status`, `providerTransactionId`, `providerReceiptNumber`)
 - payment provider factory in `paymentService` for provider-specific Form Store mapping and display detail transforms
 - `calculationService.evaluateExpression()` to evaluate OneBlink calculation expressions against submission data. Abstracts `morph-expressions` and registers `ROUND`, `ROUND_DOWN`, `ROUND_UP`, and `ISNULL`. Pass `parseDayOnlyDate` so callers control timezone-aware day-only (`YYYY-MM-DD`) date parsing (client vs server), matching the pattern used by conditional logic. Other date strings use `new Date(value)`. Returns a discriminated `EvaluateExpressionResult`: `{ type: 'RESULT', value }`, `{ type: 'MISSING_VALUES' }`, or `{ type: 'INVALID_EXPRESSION', error }` (empty expressions and parse failures; unexpected runtime errors are still thrown).

--- a/src/formElementsService.ts
+++ b/src/formElementsService.ts
@@ -310,7 +310,12 @@ function injectFormElements(
   injectAuthenticatedForms: boolean,
 ): FormTypes.FormElement[] {
   return elements.reduce<FormTypes.FormElement[]>((newElements, element) => {
-    if ('elements' in element && Array.isArray(element.elements)) {
+    if (
+      (element.type === 'page' ||
+        element.type === 'repeatableSet' ||
+        element.type === 'section') &&
+      Array.isArray(element.elements)
+    ) {
       const childElements = injectFormElements(
         element.elements,
         forms,
@@ -427,13 +432,7 @@ function resolveEmbeddedFormElement(
  */
 async function injectFormElementsIntoForms(
   forms: FormTypes.Form[],
-  getForm: (
-    formId: number,
-  ) =>
-    | FormTypes.Form
-    | undefined
-    | void
-    | Promise<FormTypes.Form | undefined | void>,
+  getForm: (formId: number) => Promise<FormTypes.Form | undefined>,
   injectAuthenticatedForms = true,
 ): Promise<void> {
   const formCache = new Map<number, FormTypes.Form | undefined>()
@@ -466,7 +465,12 @@ async function injectFormElementsAsync(
   const newElements: FormTypes.FormElement[] = []
 
   for (const element of elements) {
-    if ('elements' in element && Array.isArray(element.elements)) {
+    if (
+      (element.type === 'page' ||
+        element.type === 'repeatableSet' ||
+        element.type === 'section') &&
+      Array.isArray(element.elements)
+    ) {
       element.elements = await injectFormElementsAsync(
         element.elements,
         getForm,

--- a/src/formElementsService.ts
+++ b/src/formElementsService.ts
@@ -342,8 +342,11 @@ function injectFormElements(
           break
         }
         case 'continue': {
+          // Clone so inject mutations (e.g. containers rewritten when cycle
+          // edges are omitted) do not alter the source form, which may be
+          // shared via the forms list.
           element.elements = injectFormElements(
-            resolved.form.elements,
+            structuredClone(resolved.form.elements),
             forms,
             [...parentIds, resolved.form.id],
             injectAuthenticatedForms,
@@ -422,7 +425,8 @@ function resolveEmbeddedFormElement(
  * form is retrieved at most once across the whole batch.
  *
  * Mutates each form object in `forms` in place (the array entries are updated
- * by reference); nothing is returned.
+ * by reference); nothing is returned. Forms returned from `getForm` are not
+ * mutated — their element trees are cloned before embedding.
  *
  * @param forms The forms to inject elements into (mutated in place)
  * @param getForm Retrieves a single form by id when it is referenced by a
@@ -497,8 +501,11 @@ async function injectFormElementsAsync(
           break
         }
         case 'continue': {
+          // Clone so inject mutations (e.g. containers rewritten when cycle
+          // edges are omitted) do not alter the source form, which may be
+          // cached or a later batch root.
           element.elements = await injectFormElementsAsync(
-            resolved.form.elements,
+            structuredClone(resolved.form.elements),
             getForm,
             [...parentIds, resolved.form.id],
             injectAuthenticatedForms,

--- a/src/formElementsService.ts
+++ b/src/formElementsService.ts
@@ -310,12 +310,7 @@ function injectFormElements(
   injectAuthenticatedForms: boolean,
 ): FormTypes.FormElement[] {
   return elements.reduce<FormTypes.FormElement[]>((newElements, element) => {
-    if (
-      (element.type === 'page' ||
-        element.type === 'repeatableSet' ||
-        element.type === 'section') &&
-      Array.isArray(element.elements)
-    ) {
+    if ('elements' in element && Array.isArray(element.elements)) {
       const childElements = injectFormElements(
         element.elements,
         forms,
@@ -326,61 +321,194 @@ function injectFormElements(
     }
 
     if (element.type === 'form' || element.type === 'infoPage') {
-      const formToInject = forms.find((form) => element.formId === form.id)
-
-      if (!formToInject) {
-        const newElement: FormTypes.HtmlElement = {
-          ...element,
-          type: 'html',
-          name: 'Form_not_found',
-          label: 'Form not found.',
-          defaultValue:
-            'Unable to display the embedded form for this element, as the form was not found. Please contact your Administrator.',
-        }
-        newElements.push(newElement)
-        return newElements
-      }
-
-      if (formToInject.isAuthenticated && !injectAuthenticatedForms) {
-        console.log(
-          `No form elements injected for element id: ${element.id}, as request was unauthenticated and target form (form id: ${formToInject.id}) requires authentication.`,
-        )
-
-        const newElement: FormTypes.HtmlElement = {
-          ...element,
-          type: 'html',
-          name: 'Form_requires_authenticated',
-          label: 'Form Requires Authentication.',
-          defaultValue:
-            'Unable to display the embedded form for this element, as the form requires authentication. Please login and refresh to view this embedded form.',
-        }
-        newElements.push(newElement)
-        return newElements
-      }
-
-      const injectingParentForm =
-        parentIds && parentIds.find((id) => element.formId === id)
-
-      if (injectingParentForm) {
-        console.log(
-          `Infinite loop was detected while attempting to inject form id: ${injectingParentForm}. Ignoring elements...`,
-        )
-        return newElements
-      }
-
-      element.elements = injectFormElements(
-        formToInject.elements,
-        forms,
-        [...parentIds, formToInject.id],
+      const resolved = resolveEmbeddedFormElement(
+        element,
+        forms.find((form) => element.formId === form.id),
+        parentIds,
         injectAuthenticatedForms,
       )
-      newElements.push(element)
+
+      switch (resolved.type) {
+        case 'replace': {
+          newElements.push(resolved.element)
+          break
+        }
+        case 'skip': {
+          break
+        }
+        case 'continue': {
+          element.elements = injectFormElements(
+            resolved.form.elements,
+            forms,
+            [...parentIds, resolved.form.id],
+            injectAuthenticatedForms,
+          )
+          newElements.push(element)
+          break
+        }
+      }
     } else {
       newElements.push(element)
     }
 
     return newElements
   }, [])
+}
+
+type ResolveEmbeddedFormResult =
+  | { type: 'replace'; element: FormTypes.HtmlElement }
+  | { type: 'skip' }
+  | { type: 'continue'; form: FormTypes.Form }
+
+function resolveEmbeddedFormElement(
+  element: FormTypes.FormFormElement,
+  formToInject: FormTypes.Form | undefined,
+  parentIds: number[],
+  injectAuthenticatedForms: boolean,
+): ResolveEmbeddedFormResult {
+  if (!formToInject) {
+    return {
+      type: 'replace',
+      element: {
+        ...element,
+        type: 'html',
+        name: 'Form_not_found',
+        label: 'Form not found.',
+        defaultValue:
+          'Unable to display the embedded form for this element, as the form was not found. Please contact your Administrator.',
+      },
+    }
+  }
+
+  if (formToInject.isAuthenticated && !injectAuthenticatedForms) {
+    console.log(
+      `No form elements injected for element id: ${element.id}, as request was unauthenticated and target form (form id: ${formToInject.id}) requires authentication.`,
+    )
+
+    return {
+      type: 'replace',
+      element: {
+        ...element,
+        type: 'html',
+        name: 'Form_requires_authenticated',
+        label: 'Form Requires Authentication.',
+        defaultValue:
+          'Unable to display the embedded form for this element, as the form requires authentication. Please login and refresh to view this embedded form.',
+      },
+    }
+  }
+
+  const injectingParentForm = parentIds.find((id) => element.formId === id)
+
+  if (injectingParentForm) {
+    console.log(
+      `Infinite loop was detected while attempting to inject form id: ${injectingParentForm}. Ignoring elements...`,
+    )
+    return { type: 'skip' }
+  }
+
+  return { type: 'continue', form: formToInject }
+}
+
+/**
+ * Async counterpart to {@link injectFormElementsIntoForm}. Injects embedded
+ * `form` / `infoPage` elements for each form in `forms`. Uses `getForm` to load
+ * embedded forms and caches results by id for the duration of the call so each
+ * form is retrieved at most once across the whole batch.
+ *
+ * Mutates each form object in `forms` in place (the array entries are updated
+ * by reference); nothing is returned.
+ *
+ * @param forms The forms to inject elements into (mutated in place)
+ * @param getForm Retrieves a single form by id when it is referenced by a
+ *   `form` / `infoPage` element
+ * @param injectAuthenticatedForms Indicates whether forms requiring
+ *   authentication should be injected, defaults to true
+ */
+async function injectFormElementsIntoForms(
+  forms: FormTypes.Form[],
+  getForm: (
+    formId: number,
+  ) =>
+    | FormTypes.Form
+    | undefined
+    | void
+    | Promise<FormTypes.Form | undefined | void>,
+  injectAuthenticatedForms = true,
+): Promise<void> {
+  const formCache = new Map<number, FormTypes.Form | undefined>()
+
+  const getFormCached = async (formId: number) => {
+    if (formCache.has(formId)) {
+      return formCache.get(formId)
+    }
+    const retrieved = (await getForm(formId)) ?? undefined
+    formCache.set(formId, retrieved)
+    return retrieved
+  }
+
+  for (const form of forms) {
+    form.elements = await injectFormElementsAsync(
+      form.elements,
+      getFormCached,
+      [form.id],
+      injectAuthenticatedForms,
+    )
+  }
+}
+
+async function injectFormElementsAsync(
+  elements: FormTypes.FormElement[],
+  getForm: (formId: number) => Promise<FormTypes.Form | undefined>,
+  parentIds: number[],
+  injectAuthenticatedForms: boolean,
+): Promise<FormTypes.FormElement[]> {
+  const newElements: FormTypes.FormElement[] = []
+
+  for (const element of elements) {
+    if ('elements' in element && Array.isArray(element.elements)) {
+      element.elements = await injectFormElementsAsync(
+        element.elements,
+        getForm,
+        parentIds,
+        injectAuthenticatedForms,
+      )
+    }
+
+    if (element.type === 'form' || element.type === 'infoPage') {
+      const form = await getForm(element.formId)
+      const resolved = resolveEmbeddedFormElement(
+        element,
+        form,
+        parentIds,
+        injectAuthenticatedForms,
+      )
+
+      switch (resolved.type) {
+        case 'replace': {
+          newElements.push(resolved.element)
+          break
+        }
+        case 'skip': {
+          break
+        }
+        case 'continue': {
+          element.elements = await injectFormElementsAsync(
+            resolved.form.elements,
+            getForm,
+            [...parentIds, resolved.form.id],
+            injectAuthenticatedForms,
+          )
+          newElements.push(element)
+          break
+        }
+      }
+    } else {
+      newElements.push(element)
+    }
+  }
+
+  return newElements
 }
 
 export {
@@ -392,4 +520,5 @@ export {
   determineIsInfoPage,
   fixElementName,
   injectFormElementsIntoForm,
+  injectFormElementsIntoForms,
 }

--- a/tests/formElementsService.test.ts
+++ b/tests/formElementsService.test.ts
@@ -471,6 +471,125 @@ describe('injectFormElementsIntoForm()', () => {
       },
     ])
   })
+
+  test('does not pre-walk stub elements on form embeds before injecting', () => {
+    const injectedElements = [
+      {
+        id: 'from-injected',
+        name: 'from_injected',
+        type: 'text',
+        label: 'From Injected',
+      },
+    ]
+    const stubElements = [
+      {
+        id: 'from-stub',
+        name: 'from_stub',
+        type: 'text',
+        label: 'From Stub',
+      },
+    ]
+    const formsList = [
+      {
+        id: 1,
+        isAuthenticated: false,
+        elements: [
+          {
+            id: 'embed',
+            name: 'form',
+            type: 'form',
+            label: 'form',
+            formId: 2,
+            elements: stubElements,
+          },
+        ],
+      },
+      {
+        id: 2,
+        isAuthenticated: false,
+        elements: injectedElements,
+      },
+    ]
+
+    const result = injectFormElementsIntoForm(
+      // @ts-expect-error incomplete form fixture
+      formsList[0],
+      // @ts-expect-error incomplete form fixture
+      formsList,
+      true,
+    )
+
+    expect(result[0]).toMatchObject({
+      id: 'embed',
+      type: 'form',
+      formId: 2,
+      elements: injectedElements,
+    })
+    expect(formsList[1].elements).toEqual(injectedElements)
+  })
+
+  test('uses correct parentIds for cycle detection when form embeds have stub elements', () => {
+    // A embeds B; B embeds C; C embeds B (cycle). Stub on A's embed shares B's tree.
+    // Pre-walking that stub with parentIds=[A] (missing B) would fail to detect C→B
+    // as a cycle and re-inject B.
+    const formCElements = [
+      {
+        id: 'c-back-to-b',
+        name: 'form',
+        type: 'form',
+        label: 'form',
+        formId: 2,
+      },
+    ]
+    const formBElements = [
+      {
+        id: 'b-to-c',
+        name: 'form',
+        type: 'form',
+        label: 'form',
+        formId: 3,
+      },
+    ]
+    const formsList = [
+      {
+        id: 1,
+        isAuthenticated: false,
+        elements: [
+          {
+            id: 'a-to-b',
+            name: 'form',
+            type: 'form',
+            label: 'form',
+            formId: 2,
+            elements: formBElements,
+          },
+        ],
+      },
+      {
+        id: 2,
+        isAuthenticated: false,
+        elements: formBElements,
+      },
+      {
+        id: 3,
+        isAuthenticated: false,
+        elements: formCElements,
+      },
+    ]
+
+    const result = injectFormElementsIntoForm(
+      // @ts-expect-error incomplete form fixture
+      formsList[0],
+      // @ts-expect-error incomplete form fixture
+      formsList,
+      true,
+    )
+
+    const embedB = result[0] as FormTypes.FormFormElement
+    const embedC = embedB.elements?.[0] as FormTypes.FormFormElement
+    // C→B is a cycle once B is on the parent chain, so it must be skipped
+    expect(embedC.elements).toEqual([])
+  })
 })
 
 describe('injectFormElementsIntoForms()', () => {

--- a/tests/formElementsService.test.ts
+++ b/tests/formElementsService.test.ts
@@ -731,4 +731,78 @@ describe('injectFormElementsIntoForms()', () => {
 
     expect(retrievedFormIds).toEqual([2, 3])
   })
+
+  test('does not mutate cached getForm forms used later as batch roots', async () => {
+    // A embeds B; B has a page containing a form→A (cycle when embedded under A).
+    // Injecting A must not walk B in place and drop the cycle edge, or B as a
+    // later root would lose nested elements.
+    const formA = {
+      id: 1,
+      isAuthenticated: false,
+      elements: [
+        {
+          id: 'a-to-b',
+          name: 'form',
+          type: 'form',
+          label: 'form',
+          formId: 2,
+        },
+      ],
+    }
+    const formB = {
+      id: 2,
+      isAuthenticated: false,
+      elements: [
+        {
+          id: 'b-page',
+          name: 'page',
+          type: 'page',
+          label: 'Page',
+          elements: [
+            {
+              id: 'b-to-a',
+              name: 'form',
+              type: 'form',
+              label: 'form',
+              formId: 1,
+            },
+            {
+              id: 'b-keep',
+              name: 'keep',
+              type: 'text',
+              label: 'Keep',
+            },
+          ],
+        },
+      ],
+    }
+
+    const getForm = async (formId: number) => {
+      if (formId === 1) return formA as FormTypes.Form
+      if (formId === 2) return formB as FormTypes.Form
+      return undefined
+    }
+
+    await injectFormElementsIntoForms([formA as FormTypes.Form], getForm, true)
+
+    // B's definition is unchanged after being embedded under A
+    expect(formB.elements[0]).toMatchObject({
+      id: 'b-page',
+      type: 'page',
+      elements: [
+        { id: 'b-to-a', type: 'form', formId: 1 },
+        { id: 'b-keep', type: 'text' },
+      ],
+    })
+
+    await injectFormElementsIntoForms([formB as FormTypes.Form], getForm, true)
+
+    // B as root still sees its cycle edge and injects A under it (A→B then
+    // cycle-skips, so the embedded form has empty elements).
+    const bToA = (
+      formB.elements[0] as FormTypes.PageElement
+    ).elements?.[0] as FormTypes.FormFormElement
+    expect(bToA).toMatchObject({ id: 'b-to-a', type: 'form', formId: 1 })
+    expect(bToA.elements).toEqual([])
+  })
 })

--- a/tests/formElementsService.test.ts
+++ b/tests/formElementsService.test.ts
@@ -4,6 +4,7 @@ import { FormTypes, SubmissionTypes } from '@oneblink/types'
 import {
   findFormElement,
   injectFormElementsIntoForm,
+  injectFormElementsIntoForms,
 } from '../src/formElementsService'
 import { getRootElementValueById } from '../src/submissionService'
 import forms from './inject-forms-fixtures/valid-forms.json'
@@ -469,5 +470,146 @@ describe('injectFormElementsIntoForm()', () => {
           'Unable to display the embedded form for this element, as the form was not found. Please contact your Administrator.',
       },
     ])
+  })
+})
+
+describe('injectFormElementsIntoForms()', () => {
+  const getFormFrom =
+    (formsList: FormTypes.Form[]) => (formId: number) =>
+      formsList.find((candidate) => candidate.id === formId)
+
+  test('injects elements into a single form in place', async () => {
+    const testForms = _.cloneDeep(forms)
+
+    const form = testForms.forms[0]
+    await injectFormElementsIntoForms(
+      // @ts-expect-error ???
+      [form],
+      getFormFrom(testForms.forms),
+      true,
+    )
+    expect(form.elements).toEqual([
+      {
+        id: '1a',
+        name: 'heading',
+        type: 'heading',
+        label: 'Heading',
+      },
+      {
+        id: '1b',
+        name: 'form',
+        type: 'form',
+        label: 'form',
+        formId: 2,
+        elements: [
+          {
+            id: '2a',
+            name: 'text_1',
+            type: 'text',
+            label: 'text',
+          },
+          {
+            id: '2b',
+            name: 'form',
+            type: 'form',
+            label: 'form',
+            formId: 3,
+            elements: [
+              {
+                id: '3a',
+                name: 'text_1',
+                type: 'text',
+                label: 'text',
+                headingType: 1,
+              },
+              {
+                id: '3b',
+                name: 'text_2',
+                type: 'text',
+                label: 'text',
+              },
+            ],
+          },
+          {
+            id: '2c',
+            name: 'text_2',
+            type: 'text',
+            label: 'text',
+          },
+        ],
+      },
+      {
+        id: '1c',
+        name: 'repeatableSet',
+        type: 'repeatableSet',
+        label: 'Repeatable Set',
+        elements: [
+          {
+            id: '1c1',
+            name: 'form',
+            type: 'form',
+            label: 'form',
+            formId: 2,
+            elements: [
+              {
+                id: '2a',
+                name: 'text_1',
+                type: 'text',
+                label: 'text',
+              },
+              {
+                id: '2b',
+                name: 'form',
+                type: 'form',
+                label: 'form',
+                formId: 3,
+                elements: [
+                  {
+                    id: '3a',
+                    name: 'text_1',
+                    type: 'text',
+                    label: 'text',
+                    headingType: 1,
+                  },
+                  {
+                    id: '3b',
+                    name: 'text_2',
+                    type: 'text',
+                    label: 'text',
+                  },
+                ],
+              },
+              {
+                id: '2c',
+                name: 'text_2',
+                type: 'text',
+                label: 'text',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('retrieves each form id at most once via cache across multiple forms', async () => {
+    const testForms = _.cloneDeep(forms)
+    const formA = testForms.forms[0]
+    const formB = _.cloneDeep(testForms.forms[0])
+    formB.id = 100
+    const retrievedFormIds: number[] = []
+    const getForm = (formId: number) => {
+      retrievedFormIds.push(formId)
+      return testForms.forms.find((candidate) => candidate.id === formId)
+    }
+
+    await injectFormElementsIntoForms(
+      // @ts-expect-error ???
+      [formA, formB],
+      getForm,
+      true,
+    )
+
+    expect(retrievedFormIds).toEqual([2, 3])
   })
 })


### PR DESCRIPTION
## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core form-embedding behavior (cycle handling, cloning, traversal order) used when rendering nested forms; regressions could affect displayed structure or infinite-loop safety, though behavior is heavily tested.
> 
> **Overview**
> Adds **`injectFormElementsIntoForms()`**, an async batch API that resolves embedded `form` / `infoPage` trees via a **`getForm(formId)`** callback, **caches** each id for the whole call, and **mutates** the passed root forms in place while **cloning** loaded form element trees so cached definitions are not walked in place.
> 
> Refactors sync injection around **`resolveEmbeddedFormElement()`** (not found / auth / cycle / continue). **Cycle edges are skipped** without aborting sibling processing, embedded content is taken from **`structuredClone`** of the target form, and embed **stub `elements` are no longer pre-walked** before resolution—fixing incorrect cycle detection when stubs mirror nested graphs.
> 
> Tests cover stub vs injected trees, multi-hop cycles with stubs, batch caching, and reusing **`getForm`** results as later batch roots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603ab49c8870c0719e257666db01b4e1d595834b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->